### PR TITLE
docs: add Discord and VocaHQ README shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 [![Website](https://img.shields.io/badge/Website-vocawin.com-0078D4?style=flat-square)](https://vocawin.com)
 [![License](https://img.shields.io/badge/License-Coming%20Soon-blue?style=flat-square)](#)
+[![Discord](https://img.shields.io/discord/1538633755877580810?style=flat-square&logo=discord&logoColor=white&label=Discord)](https://discord.gg/UMJduhcqn)
+[![VocaHQ](https://img.shields.io/badge/VocaHQ-vocahq.com-1a7f4e?style=flat-square)](https://vocahq.com)
 
 ---
 


### PR DESCRIPTION
Adds two badges next to the existing README shields.

- Discord: live shields.io badge for guild 1538633755877580810. The badge links to https://discord.gg/UMJduhcqn so people can join. Online count shows once Server Widget is enabled on the Discord server.
- VocaHQ: links to https://vocahq.com for the rest of the product family.

README only.