### PR TITLE
Use a colon in the public page title

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -11,7 +11,7 @@
     <meta name="robots" content="index, follow" />
     <meta name="color-scheme" content="light" />
     <link rel="canonical" href="https://vocawin.com/" />
-    <meta property="og:title" content="VocaWin — voice typing that stays on this PC" />
+    <meta property="og:title" content="VocaWin: voice typing that stays on this PC" />
     <meta
       property="og:description"
       content="A Windows project in the Voca family. Hold a hotkey, speak, and text is meant to land at your cursor. Speech-to-text is designed to run on this PC. No public installer yet."
@@ -30,7 +30,7 @@
       content="VocaWin: Windows voice typing that stays on this PC. Coming soon. Part of VocaHQ."
     />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="VocaWin — voice typing that stays on this PC" />
+    <meta name="twitter:title" content="VocaWin: voice typing that stays on this PC" />
     <meta
       name="twitter:description"
       content="Windows voice typing for the Voca family. Designed to run on this PC. No public installer yet."
@@ -40,7 +40,7 @@
       name="twitter:image:alt"
       content="VocaWin: Windows voice typing that stays on this PC. Coming soon. Part of VocaHQ."
     />
-    <title>VocaWin — voice typing that stays on this PC</title>
+    <title>VocaWin: voice typing that stays on this PC</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <link rel="icon" href="assets/brand/voca-logo-512.png" type="image/png" sizes="512x512" />
     <link rel="apple-touch-icon" href="assets/apple-touch-icon.png" />

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -10,7 +10,7 @@ const css = readFileSync(join(siteRoot, "styles.css"), "utf8");
 const script = readFileSync(join(siteRoot, "script.js"), "utf8");
 
 test("page has one title and landmark structure", () => {
-  assert.match(html, /<title>VocaWin — voice typing that stays on this PC<\/title>/);
+  assert.match(html, /<title>VocaWin: voice typing that stays on this PC<\/title>/);
   assert.equal((html.match(/<h1\b/g) || []).length, 1);
   assert.match(html, /<main id="main-content">/);
   assert.match(html, /<nav[^>]+aria-label="Main navigation"/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The public document title used an em dash. Linux uses a colon, so the browser tab and matching social titles now read:

VocaWin: voice typing that stays on this PC

This updates only the `<title>`, `og:title`, and `twitter:title` on the site, plus the test that checks the title. Body copy is unchanged.

Not for merge until you say so. Leaves #9 alone.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b21166af-bbdf-482b-895e-88e35c09605f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b21166af-bbdf-482b-895e-88e35c09605f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

