### PR TITLE
Cache Windows cargo so CI reuses the whisper build

### DIFF
--- a/.github/workflows/windows-alpha-release.yml
+++ b/.github/workflows/windows-alpha-release.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: write
+      actions: write
     env:
       CARGO_TARGET_DIR: C:\t
       CMAKE_GENERATOR: Ninja
@@ -38,6 +39,12 @@ jobs:
           node-version: 22
           cache: npm
       - uses: dtolnay/rust-toolchain@stable
+      # Cache C:\t (CARGO_TARGET_DIR). Later v* tags reuse this job's artifacts.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          cache-targets: false
+          cache-directories: C:/t
       - name: Install CMake, LLVM, Ninja, and Vulkan SDK
         shell: pwsh
         run: |

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: read
+      actions: write
     env:
       # Short target dir avoids MAX_PATH in whisper.cpp vulkan-shaders-gen nests.
       CARGO_TARGET_DIR: C:\t
@@ -28,6 +29,13 @@ jobs:
           node-version: 22
           cache: npm
       - uses: dtolnay/rust-toolchain@stable
+      # rust-cache joins workspaces targets as relative paths, so C:\t has to
+      # go in cache-directories. Job-scoped key keeps debug and release apart.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          cache-targets: false
+          cache-directories: C:/t
       - name: Install CMake, LLVM, Ninja, and Vulkan SDK
         shell: pwsh
         run: |
@@ -65,6 +73,12 @@ jobs:
           node-version: 22
           cache: npm
       - uses: dtolnay/rust-toolchain@stable
+      # Same C:\t cache as the test job. Separate job key (debug vs release).
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          cache-targets: false
+          cache-directories: C:/t
       - name: Install CMake, LLVM, Ninja, and Vulkan SDK
         shell: pwsh
         run: |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Windows CI only cached npm, so every PR and tag compiled whisper.cpp and the Tauri crate into a cold C:\t.

This adds rust-cache after the toolchain on the test job, the unsigned installer job, and the tag release job. rust-cache joins workspace targets as relative paths, so C:\t is saved through cache-directories instead of `src-tauri -> C:\t`. The key still follows Cargo.lock, rustc, and the CARGO_/CMAKE_ env, so a lockfile bump starts clean.

Test and installer stay parallel. They keep separate keys because one is debug and the other is release. Sharing one key would let the faster test job freeze a debug-only cache, and the installer would still compile whisper.cpp. A miss just builds like today.

No tagName on the PR installer. Tag Releases stay in windows-alpha-release.yml. No product copy changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e53a2a72-eddf-465b-817b-758fbb7038d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e53a2a72-eddf-465b-817b-758fbb7038d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

