### PR TITLE
Drop leftover Coming soon copy from the README

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -9,10 +9,52 @@ on:
 permissions:
   contents: read
   actions: write
+  pull-requests: read
+
+# Do not use on.pull_request.paths. That can skip the whole workflow
+# and leave a required check pending. Filter in a cheap ubuntu job
+# instead, then skip the Windows VMs when only docs changed.
 
 jobs:
+  changes:
+    name: Check source changes
+    runs-on: ubuntu-latest
+    outputs:
+      source: ${{ steps.report.outputs.source }}
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event_name != 'workflow_dispatch'
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          filters: |
+            source:
+              - 'src/**'
+              - 'src-tauri/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'index.html'
+              - 'vite.config.*'
+              - 'tsconfig*.json'
+              - '.github/workflows/windows-ci.yml'
+              - '.github/scripts/**'
+      - id: report
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "source=true"
+            echo "source=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "source=${{ steps.filter.outputs.source }}"
+            echo "source=${{ steps.filter.outputs.source }}" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+
   test:
     name: Build and test on Windows
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.source == 'true'
     runs-on: windows-latest
     permissions:
       contents: read
@@ -62,8 +104,10 @@ jobs:
 
   installer:
     name: Windows installer (alpha)
-    # PRs only cargo test. Packaging NSIS/MSI is main + workflow_dispatch.
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: changes
+    # PRs never package. Main packages only when app/workflow source
+    # changed. workflow_dispatch still builds test + installer.
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && needs.changes.outputs.source == 'true')
     runs-on: windows-latest
     env:
       CARGO_TARGET_DIR: C:\t

--- a/README.md
+++ b/README.md
@@ -27,32 +27,32 @@ It sits next to [VocaLinux](https://vocalinux.com), [VocaMac](https://vocamac.co
 - **Windows native** - Tray app, hotkey, WASAPI, text at the caret
 - **Honest status** - Developer alpha. Unsigned. Windows will likely say the publisher is unknown.
 
-## Planned Features
+## Try it
 
-- **System-wide text injection** - Transcribed text appears wherever your cursor is
-- **Push-to-talk and toggle** - Hold a hotkey (default: Right Alt, like VocaLinux) or double-tap to toggle
-- **GPU acceleration** - NVIDIA CUDA, AMD, and Intel paths via whisper.cpp
-- **Language support** - Follows the selected Whisper model
-- **Configurable settings** - Hotkeys, models, languages, silence detection
-- **Visual feedback** - Tray icon states for idle, recording, and processing
-- **Clipboard preservation** - Save and restore the clipboard after injection
+Testers can install an unsigned developer alpha today. Download the NSIS `.exe` or the MSI from [GitHub Releases](https://github.com/VocaHQ/vocawin/releases). The latest tagged build is [v0.1.0-alpha.1](https://github.com/VocaHQ/vocawin/releases/tag/v0.1.0-alpha.1). Windows will likely say the publisher is unknown. That is SmartScreen. More info, then Run anyway if you trust the file. Read [the setup guide](docs/setup.md) first.
 
-## Foundation in progress
+This is a tester build you can run today. It is not a store listing and not a stable public release.
 
-The repo already contains an early Rust + Tauri 2 shell used for local development. This is not a public release.
+### What works
 
-- Privacy-first settings model (no account, telemetry, or transcription endpoint)
-- Local model catalog covering Whisper/whisper.cpp, Distil-Whisper, Parakeet, Moonshine, SenseVoice, GigaAM, and Canary
-- One-click in-app model Download into the layout each recognizer expects
-- Microphone capture, sample-rate conversion, and offline Whisper transcription through `whisper-rs` / whisper.cpp
-- ONNX Runtime adapters for Parakeet TDT, Moonshine, SenseVoice, GigaAM, and Canary; DirectML is enabled in Windows builds
-- Native Unicode text injection for Windows (`SendInput`), isolated from recognition engines
-- System tray with Show window / Quit, and close-to-tray
-- Settings dashboard built with TypeScript and Vite
+- **Hold a hotkey, speak, text at the caret** - Default is Right Alt, the same hold as VocaLinux. Double-tap toggles. You can change the hotkey in Settings.
+- **Tray** - Idle, recording, and processing icon states. Close goes to the tray. Show window / Quit.
+- **Settings** - Hotkeys, models, languages, silence detection, sounds, start on login.
+- **Local models** - In-app Download for Whisper/whisper.cpp, Distil-Whisper, Parakeet, Moonshine, SenseVoice, GigaAM, and Canary.
+- **GPU** - whisper.cpp on Vulkan with CPU fallback. ONNX Runtime on DirectML with CPU fallback.
+- **Clipboard restore** after injection.
 
-The recognizer is intentionally not stubbed as a cloud API: VocaWin will only invoke a locally installed/downloaded engine. Model downloads may use the network once, but audio and transcription never do.
+### Still rough
 
-### Architecture (development)
+- Unsigned / self-signed. SmartScreen is expected. There is no purchased CA signature and no Microsoft Store listing.
+- The installer does not bundle a speech model. First run needs a network once to download one.
+- Elevated windows can block text injection.
+- Parakeet CTC and Vosk stay out of the catalog until they work.
+- No auto-update. Expect bugs. [File an issue](https://github.com/VocaHQ/vocawin/issues) if something breaks.
+
+The recognizer is not a cloud API. VocaWin only invokes a locally installed or downloaded engine. Model downloads may use the network once. Audio and transcription do not.
+
+### Architecture
 
 ```text
 Tauri UI (TypeScript)
@@ -98,12 +98,12 @@ Same privacy bar, different machines. Start at [vocahq.com](https://vocahq.com) 
 
 VocaGateway is optional self-hosted compute for other Voca clients. VocaWin does not expose a gateway mode today.
 
-## Tech Stack (Planned)
+## Tech Stack
 
-- **Speech Engine**: [whisper.cpp](https://github.com/ggerganov/whisper.cpp) with GPU acceleration
+- **Speech Engine**: [whisper.cpp](https://github.com/ggerganov/whisper.cpp) and ONNX Runtime, both local
 - **Platform**: Windows 10/11
-- **GPU Support**: NVIDIA CUDA, AMD, Intel
-- **Languages**: determined by the downloaded Whisper model
+- **GPU**: Vulkan for Whisper, DirectML for ONNX, CPU fallback for both
+- **Languages**: determined by the downloaded model
 
 ## Development
 
@@ -122,7 +122,7 @@ Windows CI builds an NSIS (and MSI) installer on pushes to main and on workflow_
 
 Pushing a `v*` tag (for example `v0.1.0-alpha.1`) builds the same NSIS and MSI and attaches them to a GitHub Release marked as a prerelease. Testers should use [Releases](https://github.com/VocaHQ/vocawin/releases), not the workflow artifact. The build is self-signed, not a purchased CA or store signature. Windows will likely still warn. More info, then Run anyway. There is no Microsoft Store listing and no auto-update. Read [the setup guide](docs/setup.md) before you install, and [file an issue](https://github.com/VocaHQ/vocawin/issues) if something breaks. [vocawin.com](https://vocawin.com) points at the same download.
 
-## System Requirements (planned)
+## System Requirements
 
 - Windows 10 version 1809 or later, or Windows 11
 - 4 GB RAM (8 GB+ recommended for larger models)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The README header already said Developer alpha. Further down it still sounded like the product had not shipped anything.

Planned Features listed tray, hotkey, GPU, and settings as if they were still future work. Foundation in progress called the app an early local-dev shell and said this is not a public release. Tech Stack and System Requirements still had leftover Planned labels.

This rewrite tells a visitor they can try the unsigned alpha from GitHub Releases today, what already works, and what is still rough. SmartScreen unknown-publisher stays in the caveats. No store or signed-build claim.

Windows CI now has a cheap ubuntu path filter so a docs-only PR does not sit through cargo test or packaging. The workflow still starts and reports whether source changed. Windows jobs run only when app or workflow files changed, or on a manual dispatch. Installer still never runs on pull requests. A README-only merge to main does not package.

This PR also touches windows-ci.yml, so the filter treats it as source and the Windows jobs will still run here. Later README-only PRs should skip the VM.

vocawin.com, installer tag releases, and the tone-picker work are left alone. GitHub repo description and topics are being updated separately.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-666a462c-63a4-45c5-96fe-9f473c555f94?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-666a462c-63a4-45c5-96fe-9f473c555f94&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

