### PR TITLE
Point Discord at the current VocaHQ invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 [![License](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
 [![Website](https://img.shields.io/badge/Website-vocawin.com-informational)](https://vocawin.com)
-[![Discord](https://img.shields.io/discord/1538633755877580810?logo=discord&logoColor=white&label=Discord)](https://discord.gg/UMJduhcqn)
+[![Discord](https://img.shields.io/discord/1538633755877580810?logo=discord&logoColor=white&label=Discord)](https://discord.gg/t6muquAJbm)
 [![Follow us](https://img.shields.io/badge/Follow%20us-000000?logo=x&logoColor=white)](https://x.com/vocahq)
 [![VocaHQ](https://img.shields.io/badge/VocaHQ-vocahq.com-1a7f4e)](https://vocahq.com)
 

--- a/web/index.html
+++ b/web/index.html
@@ -814,6 +814,8 @@
         <div>
           <p>say hello</p>
           <a href="https://github.com/VocaHQ">VocaHQ on GitHub</a>
+          <a href="https://discord.gg/t6muquAJbm">Discord</a>
+          <a href="https://x.com/vocahq">X @vocahq</a>
           <a href="mailto:hello@vocahq.com">hello@vocahq.com</a>
         </div>
       </nav>

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -84,6 +84,8 @@ test("vocahq.com and the family are linked", () => {
   assert.match(html, /href="https:\/\/vocaphone\.vocahq\.com\/"/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocagateway"/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocawin"/);
+  assert.match(html, /href="https:\/\/discord\.gg\/t6muquAJbm"/);
+  assert.match(html, /href="https:\/\/x\.com\/vocahq"/);
   assert.doesNotMatch(html, /jatinkrmalik\/vocawin/);
 });
 


### PR DESCRIPTION
## Why

We are standing up a shared VocaHQ community so contributors and testers can talk to us without waiting on GitHub issues. The old Discord invite is stale.

## What changed

- Discord invite is now https://discord.gg/t6muquAJbm
- X / Twitter follow shields and public follow links now point at [@vocahq](https://x.com/vocahq) instead of @jatinkrmalik
- Discord is also in contributing/support docs and site footers where people look for help

Personal GitHub credits, old Homebrew tap names, and maintainer emails are unchanged.

## Review

Please approve and merge if the invite and @vocahq handle look right.

Touched: README Discord badge, vocawin.com footer.