### PR TITLE
Add nightly Windows installer for testers

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,222 @@
+# Moving GitHub Release tagged `nightly` for testers who want today's main.
+# Does not replace the v* alpha. windows-alpha-release.yml still owns tagged cuts.
+# Tag name is `nightly`, not v*, so it cannot fire the alpha workflow.
+# Installers stay unsigned. SmartScreen is expected.
+
+name: Nightly
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: nightly-build
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check for source changes
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check.outputs.has_changes }}
+      short_sha: ${{ steps.check.outputs.short_sha }}
+      date: ${{ steps.check.outputs.date }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          fetch-tags: true
+
+      - id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          DATE=$(date -u +%Y%m%d)
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "date=${DATE}" >> "$GITHUB_OUTPUT"
+          echo "HEAD $(git rev-parse HEAD) (${SHORT_SHA})"
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "workflow_dispatch: building"
+            exit 0
+          fi
+
+          git fetch origin tag nightly --no-tags 2>/dev/null || true
+          if ! git rev-parse -q --verify refs/tags/nightly >/dev/null; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "no nightly tag yet: building"
+            exit 0
+          fi
+
+          NIGHTLY=$(git rev-parse refs/tags/nightly)
+          HEAD=$(git rev-parse HEAD)
+          if [ "$HEAD" = "$NIGHTLY" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "HEAD matches nightly ${NIGHTLY}: skip"
+            exit 0
+          fi
+
+          CHANGED=$(git diff --name-only "$NIGHTLY"..HEAD)
+          echo "$CHANGED"
+          if echo "$CHANGED" | grep -Eq '^(src/|src-tauri/|package.json|package-lock.json|index.html|vite.config|tsconfig|\.github/workflows/nightly\.yml|\.github/workflows/windows-ci\.yml|\.github/scripts/)'; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "source changed since nightly: building"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "no app source changes since nightly: skip"
+          fi
+
+  nightly:
+    name: Build and publish nightly
+    needs: check
+    if: needs.check.outputs.has_changes == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 90
+    env:
+      CARGO_TARGET_DIR: C:\t
+      CMAKE_GENERATOR: Ninja
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          cache-targets: false
+          cache-directories: C:/t
+
+      - name: Install CMake, LLVM, Ninja, and Vulkan SDK
+        shell: pwsh
+        run: |
+          choco install cmake llvm ninja -y --no-progress
+          echo "LIBCLANG_PATH=C:\Program Files\LLVM\bin" >> $env:GITHUB_ENV
+          echo "C:\Program Files\CMake\bin" >> $env:GITHUB_PATH
+          echo "C:\Program Files\LLVM\bin" >> $env:GITHUB_PATH
+          $ver = "1.3.290.0"
+          $installer = "$env:RUNNER_TEMP\VulkanSDK.exe"
+          Invoke-WebRequest "https://sdk.lunarg.com/sdk/download/$ver/windows/VulkanSDK-$ver-Installer.exe" -OutFile $installer
+          Start-Process -FilePath $installer -ArgumentList "--accept-licenses --default-answer --confirm-command install" -Wait
+          echo "VULKAN_SDK=C:\VulkanSDK\$ver" >> $env:GITHUB_ENV
+          echo "C:\VulkanSDK\$ver\Bin" >> $env:GITHUB_PATH
+
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Test Rust command layer
+        run: cargo test --manifest-path src-tauri/Cargo.toml
+
+      - name: Build NSIS and MSI
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_TARGET_DIR: C:\t
+          CMAKE_GENERATOR: Ninja
+        with:
+          args: --bundles nsis,msi
+          includeUpdaterJson: false
+
+      - name: Stage nightly installers
+        shell: pwsh
+        env:
+          SHORT_SHA: ${{ needs.check.outputs.short_sha }}
+          NIGHTLY_DATE: ${{ needs.check.outputs.date }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $nsis = Get-ChildItem "C:\t\release\bundle\nsis\*-setup.exe" | Select-Object -First 1
+          $msi = Get-ChildItem "C:\t\release\bundle\msi\*.msi" | Select-Object -First 1
+          if (-not $nsis -or -not $msi) {
+            throw "Missing NSIS or MSI under C:\t\release\bundle"
+          }
+          New-Item -ItemType Directory -Force nightly-out | Out-Null
+          Copy-Item $nsis.FullName "nightly-out\VocaWin-nightly-$env:NIGHTLY_DATE-$env:SHORT_SHA-x64-setup.exe"
+          Copy-Item $msi.FullName "nightly-out\VocaWin-nightly-$env:NIGHTLY_DATE-$env:SHORT_SHA-x64.msi"
+          Copy-Item $nsis.FullName "nightly-out\VocaWin-nightly-x64-setup.exe"
+          Copy-Item $msi.FullName "nightly-out\VocaWin-nightly-x64.msi"
+          Get-FileHash "nightly-out\*" -Algorithm SHA256 |
+            ForEach-Object { "{0}  {1}" -f $_.Hash.ToLowerInvariant(), (Split-Path $_.Path -Leaf) } |
+            Set-Content -Encoding ascii nightly-out\checksums.txt
+          Get-ChildItem nightly-out | Format-Table Name, Length
+          Get-Content nightly-out\checksums.txt
+
+      - name: Publish moving nightly release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHORT_SHA: ${{ needs.check.outputs.short_sha }}
+          NIGHTLY_DATE: ${{ needs.check.outputs.date }}
+        shell: pwsh
+        run: |
+          $PSNativeCommandUseErrorActionPreference = $false
+          $isoDate = [datetime]::ParseExact($env:NIGHTLY_DATE, "yyyyMMdd", $null).ToString("yyyy-MM-dd")
+          $repo = $env:GITHUB_REPOSITORY
+          $sha = (git rev-parse HEAD)
+          $sums = (Get-Content nightly-out\checksums.txt -Raw).Trim()
+          $fence = '```'
+          $notes = @(
+            "Unsigned installer from ``main`` @ ``$($env:SHORT_SHA)``. This is not the tagged alpha.",
+            "",
+            "Windows will likely say the publisher is unknown. That is SmartScreen. More info, then Run anyway if you trust the file. There is no store signature and no auto-update.",
+            "",
+            "Prefer the latest ``v*`` alpha if you want the last cut we named. Use nightly if you want today's tree.",
+            "",
+            "## Install",
+            "",
+            "- ``VocaWin-nightly-x64-setup.exe`` — NSIS, current-user",
+            "- ``VocaWin-nightly-x64.msi`` — WiX wizard",
+            "",
+            "Use one, not both, on the same PC. Read the [setup guide](https://github.com/VocaHQ/vocawin/blob/main/docs/setup.md) first.",
+            "",
+            "## Build",
+            "",
+            "- Date (UTC): $isoDate",
+            "- Commit: $($env:SHORT_SHA)",
+            "- Branch: main",
+            "",
+            "## Checksums (SHA-256)",
+            "",
+            $fence,
+            $sums,
+            $fence,
+            "",
+            "File an [issue](https://github.com/VocaHQ/vocawin/issues) if it breaks. Say it is a nightly and include the commit above."
+          ) -join "`n"
+          [System.IO.File]::WriteAllText("$pwd\release-notes.md", $notes + "`n")
+
+          gh release delete nightly --yes --cleanup-tag --repo $repo
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "no existing nightly release (ok)"
+          }
+
+          gh release create nightly `
+            --title "VocaWin nightly — $isoDate ($($env:SHORT_SHA))" `
+            --notes-file release-notes.md `
+            --prerelease `
+            --target $sha `
+            --repo $repo `
+            nightly-out/VocaWin-nightly-x64-setup.exe `
+            nightly-out/VocaWin-nightly-x64.msi `
+            nightly-out/VocaWin-nightly-$($env:NIGHTLY_DATE)-$($env:SHORT_SHA)-x64-setup.exe `
+            nightly-out/VocaWin-nightly-$($env:NIGHTLY_DATE)-$($env:SHORT_SHA)-x64.msi `
+            nightly-out/checksums.txt
+          if ($LASTEXITCODE -ne 0) { throw "gh release create failed" }

--- a/.github/workflows/windows-alpha-release.yml
+++ b/.github/workflows/windows-alpha-release.yml
@@ -3,6 +3,7 @@
 #
 # Tag push is the only trigger. windows-ci.yml must never set tagName.
 # PRs only cargo test. Main uploads the installer artifact.
+# Nightlies are a different tag (`nightly`) in nightly.yml.
 # Always prerelease: a GitHub Release here is not a public ship.
 # No workflow_dispatch, so a branch click cannot publish.
 # includeUpdaterJson is off so we do not upload latest.json.

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -148,8 +148,9 @@ jobs:
           CARGO_TARGET_DIR: C:\t
           CMAKE_GENERATOR: Ninja
         with:
-          # Build only. Do not set tagName. Tag Releases live in
-          # windows-alpha-release.yml so main stays artifact-only.
+          # Build only. Do not set tagName. Tagged alpha Releases live in
+          # windows-alpha-release.yml. The moving nightly Release lives in
+          # nightly.yml. This job stays artifact-only.
           args: --bundles nsis,msi
           includeUpdaterJson: false
       # tauri-action with CARGO_TARGET_DIR=C:\t writes:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 <div align="center">
 
-[![Release](https://img.shields.io/github/v/release/VocaHQ/vocawin?include_prereleases)](https://github.com/VocaHQ/vocawin/releases)
+[![Release](https://img.shields.io/github/v/release/VocaHQ/vocawin?include_prereleases&sort=semver)](https://github.com/VocaHQ/vocawin/releases)
+[![Nightly](https://img.shields.io/badge/Nightly-download-blueviolet)](https://github.com/VocaHQ/vocawin/releases/tag/nightly)
 [![Status](https://img.shields.io/badge/status-developer%20alpha-yellow)](#development)
 [![Platform](https://img.shields.io/badge/platform-Windows%2010%2F11-lightgrey)](#system-requirements)
 [![Privacy](https://img.shields.io/badge/privacy-on%20this%20PC-success)](#key-principles)
@@ -43,6 +44,8 @@ It sits next to [VocaLinux](https://vocalinux.com), [VocaMac](https://vocamac.co
 ## Try it
 
 Testers can install an unsigned developer alpha today. Download the NSIS `.exe` or the MSI from [GitHub Releases](https://github.com/VocaHQ/vocawin/releases). Windows will likely say the publisher is unknown. That is SmartScreen. More info, then Run anyway if you trust the file. Read [the setup guide](docs/setup.md) first.
+
+Want today's `main` instead of the last tagged alpha? Use the [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly). Same unsigned NSIS and MSI, rebuilt when app source on `main` changes. Prefer the tagged alpha if you want the last cut we named.
 
 This is a tester build you can run today. It is not a store listing and not a stable public release.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Cutting a Windows alpha
 
-This is the checklist we already use. A `v*` tag is what ships a tester build. There is no second path.
+This is the checklist we already use. A `v*` tag is what ships a **named** tester alpha. Nightlies are a second path: `.github/workflows/nightly.yml` publishes a moving `nightly` prerelease from `main` when app source changed. Do not use a `v*` tag for a nightly. Do not retag `nightly` by hand unless you are replacing a broken publish.
 
 ## Tag
 
@@ -14,7 +14,9 @@ Do not retag. Do not use workflow_dispatch. `.github/workflows/windows-alpha-rel
 
 A `v*` tag push runs `windows-alpha-release.yml`. tauri-action builds unsigned NSIS and MSI and attaches them to a GitHub Release named `VocaWin <tag> (Windows alpha)`. The Release is always a prerelease. `includeUpdaterJson` stays off. There is no store signature and no auto-update.
 
-`windows-ci.yml` on main still uploads a workflow artifact. Testers should ignore that and use the GitHub Release.
+`windows-ci.yml` on main still uploads a workflow artifact. Testers should ignore that and use a GitHub Release: the tagged `v*` alpha, or [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly) if they want today's `main`.
+
+The nightly Release is always a prerelease named `nightly`. It is deleted and recreated; the URL stays the same. The README release badge uses `sort=semver` so `nightly` does not steal it from `v*`.
 
 tauri-action writes a generic body about vocawin.com and SmartScreen. If you drafted real notes before the job finished, they get overwritten. Put the notes and the Ready screenshot back after the installers land.
 
@@ -32,7 +34,7 @@ You can rename the Release to drop the `v` and the `(Windows alpha)` suffix. Tha
 
 ## Public pages
 
-[vocawin.com](https://vocawin.com) lives in `web/` and publishes from `main` when `web/` changes. Download buttons already go to [Releases](https://github.com/VocaHQ/vocawin/releases). Do not pin a tag in the hero, the FAQ, or JSON-LD. After this checklist landed, the site should not name a specific tag at all. Check the live page still says developer alpha, unsigned, More info then Run anyway, and that every download still hits `/releases`.
+[vocawin.com](https://vocawin.com) lives in `web/` and publishes from `main` when `web/` changes. The hero download still goes to [Releases](https://github.com/VocaHQ/vocawin/releases), not a `v*` tag. A quieter [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly) link is allowed because that tag is moving, not a version pin. Do not pin `v0.1.0-alpha.N` in the hero, the FAQ, or JSON-LD. Check the live page still says developer alpha, unsigned, More info then Run anyway.
 
 The README badge is `github/v/release` with `include_prereleases`. It tracks the latest prerelease by itself. Leave it pointed at `/releases`. Do not pin a tag in the README.
 
@@ -48,4 +50,4 @@ VocaHQ owns vocahq.com and the family PRODUCT.md. If that page still lists an ol
 
 ## What not to do
 
-Do not pin a tag in the README or on vocawin.com. Do not bump the `0.1.0` app version for an alpha. Do not tell testers the build is signed, Coming soon, or Available now. Do not cut a release from a branch click.
+Do not pin a `v*` tag in the README or on vocawin.com. Do not bump the `0.1.0` app version for an alpha or a nightly. Do not tell testers the build is signed, Coming soon, or Available now. Do not cut an alpha from a branch click. Nightly may be dispatched by hand.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -2,6 +2,8 @@
 
 This is the tester page for the VocaWin alpha. [vocawin.com](https://vocawin.com) points testers at [GitHub Releases](https://github.com/VocaHQ/vocawin/releases). There is no Voca account and no hosted speech API.
 
+The tagged alpha is the last cut we named. If you want today's `main`, use the [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly). Same unsigned NSIS and MSI. Say it is a nightly and include the commit from that Release if you file an issue.
+
 The NSIS and MSI are unsigned. That is not a store signature. Windows will likely say the publisher is unknown. That is SmartScreen. Use More info, then Run anyway, only if you trust the GitHub Release you downloaded.
 
 There are two installers. The NSIS `.exe` is a current-user setup. The MSI is the WiX wizard. Use one, not both, on the same PC.

--- a/web/README.md
+++ b/web/README.md
@@ -1,6 +1,6 @@
 # vocawin.com
 
-Static landing page for VocaWin. No build step, no trackers, system fonts. The page points testers at the unsigned developer alpha on GitHub Releases.
+Static landing page for VocaWin. No build step, no trackers, system fonts. The page points testers at the unsigned developer alpha on GitHub Releases, with a quieter link to the moving `nightly` tag.
 
 ```bash
 python3 -m http.server 4173 --directory .

--- a/web/index.html
+++ b/web/index.html
@@ -193,6 +193,8 @@
             <a href="https://github.com/VocaHQ/vocawin/issues">file an issue</a>
             <span aria-hidden="true">·</span>
             <a href="https://github.com/VocaHQ/vocawin">source</a>
+            <span aria-hidden="true">·</span>
+            <a href="https://github.com/VocaHQ/vocawin/releases/tag/nightly">nightly from main</a>
           </p>
           <p class="hero-note">
             Developer alpha. Unsigned. Windows will likely say the publisher is
@@ -540,6 +542,8 @@
               <a href="https://github.com/VocaHQ/vocawin/issues">file an issue</a>
               ·
               <a href="https://github.com/VocaHQ/vocawin">source</a>
+              ·
+              <a href="https://github.com/VocaHQ/vocawin/releases/tag/nightly">nightly from main</a>
             </p>
           </article>
           <article class="status-card reveal">
@@ -710,6 +714,17 @@
             </p>
           </details>
           <details>
+            <summary>Is there a nightly?<span aria-hidden="true">＋</span></summary>
+            <p>
+              Yes. A moving unsigned build from
+              <code>main</code> is on the
+              <a href="https://github.com/VocaHQ/vocawin/releases/tag/nightly">nightly</a>
+              GitHub Release. Same SmartScreen story as the alpha. Prefer the
+              tagged alpha if you want the last cut we named. Nightly is for
+              testers who want today's tree.
+            </p>
+          </details>
+          <details>
             <summary>Does my voice stay on this PC?<span aria-hidden="true">＋</span></summary>
             <p>
               That is the design. After a Whisper model is downloaded, recording
@@ -801,6 +816,7 @@
           <a href="#privacy">privacy</a>
           <a href="#status">availability</a>
           <a href="https://github.com/VocaHQ/vocawin/releases">Releases</a>
+          <a href="https://github.com/VocaHQ/vocawin/releases/tag/nightly">Nightly</a>
           <a href="https://github.com/VocaHQ/vocawin">GitHub</a>
         </div>
         <div>

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -36,7 +36,11 @@ test("unsigned alpha download is explicit and not oversold", () => {
     /class="hero-copy"[\s\S]*class="button button-primary" href="https:\/\/github\.com\/VocaHQ\/vocawin\/releases"/,
   );
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocawin\/releases"/);
-  assert.doesNotMatch(html, /\/releases\/tag\//);
+  assert.match(
+    html,
+    /href="https:\/\/github\.com\/VocaHQ\/vocawin\/releases\/tag\/nightly"/,
+  );
+  assert.doesNotMatch(html, /\/releases\/tag\/v/);
   assert.doesNotMatch(html, /softwareVersion/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocawin\/issues"/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocawin\/blob\/main\/docs\/setup\.md"/);


### PR DESCRIPTION
## Summary

Testers who want today’s `main` can grab a nightly instead of waiting for the next `v*` alpha.

- New `.github/workflows/nightly.yml` builds unsigned NSIS + MSI and publishes a moving prerelease tagged `nightly` (same URL every day)
- Skips the Windows job when `main` has no app-source changes since the last nightly
- `workflow_dispatch` still builds on demand
- Does not bump `0.1.0` and does not fire `windows-alpha-release.yml` (`nightly` is not `v*`)
- README badge uses `sort=semver` so `nightly` does not steal the alpha version badge
- vocawin.com hero still downloads the alpha; quieter links go to `/releases/tag/nightly`

Stable download URLs after the first successful run:

- https://github.com/VocaHQ/vocawin/releases/tag/nightly
- https://github.com/VocaHQ/vocawin/releases/download/nightly/VocaWin-nightly-x64-setup.exe
- https://github.com/VocaHQ/vocawin/releases/download/nightly/VocaWin-nightly-x64.msi

## Verification

- [x] `node --test tests/site.test.mjs` in `web/`
- First nightly publishes after merge (schedule 04:00 UTC, or Actions → Nightly → Run workflow)