### PR TITLE
fix: do not take over the clipboard when inserting text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Rust modules (keep work in the matching file):
 | `devices.rs` | WASAPI mic list via cpal |
 | `whisper_cache.rs` | whisper.cpp keep-alive + optional idle unload |
 | `gpu.rs` / `hardware.rs` | DXGI GPU pick (skip WARP) and starting-model hint |
-| `output.rs` | Clipboard paste + restore; `SendInput` fallback |
+| `output.rs` | `SendInput` first (clipboard left alone); clipboard paste + restore fallback; optional copy-to-clipboard |
 | `autopause.rs` / `power.rs` | Opt-in app pause; sleep/wake hotkey rebind |
 | `sounds.rs` / `logbuf.rs` | PlaySound themes; in-memory logs (not a file) |
 
@@ -91,7 +91,7 @@ src/main.ts (dictation / models / history / settings; #logs window)
       ├─ whisper.cpp (GGML .bin) via whisper_cache
       ├─ ONNX (Parakeet TDT, Moonshine, SenseVoice, GigaAM, Canary)
       ├─ Tray (idle / listening / processing)
-      └─ inject: clipboard Ctrl+V + restore, else SendInput
+      └─ inject: SendInput (no clipboard); clipboard Ctrl+V + restore fallback
 ```
 
 Do not add a frontend framework. Add Tauri commands next to the existing `invoke_handler` list and call them with `invoke()` from `src/main.ts`.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This is a tester build you can run today. It is not a store listing and not a st
 - **Settings** - Hotkeys, models, languages, silence detection, sounds, start on login.
 - **Local models** - In-app Download for Whisper/whisper.cpp, Distil-Whisper, Parakeet, Moonshine, SenseVoice, GigaAM, and Canary.
 - **GPU** - whisper.cpp on Vulkan with CPU fallback. ONNX Runtime on DirectML with CPU fallback.
-- **Clipboard restore** after injection.
+- **Clipboard stays yours.** Insertion types at the caret and does not replace what you copied. Turn on Copy to clipboard in Settings if you want the transcript left there. Clipboard paste is only a fallback, and that path restores the previous clipboard.
 
 ### Still rough
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -23,7 +23,7 @@ This checklist tracks the path from the current local-recognition foundation to 
 - [x] New-install default hotkey Right Alt (VocaLinux hold-default; AltGr left alone). Existing TROOPER Ctrl+Alt+Space settings kept until changed
 - [x] Silence energy auto-stop in toggle mode only (PTT stops on key-up); `silence_seconds` wired
 - [x] Trailing space and auto-capitalize output polish
-- [x] Clipboard + paste inject with restore (SendInput fallback)
+- [x] SendInput inject by default (clipboard left alone); clipboard paste + restore fallback; optional copy-to-clipboard (off by default)
 - [x] Start/stop/error sound cues when enabled (PlaySound WAV; not silent Beep)
 - [x] Local transcription history with clear-history control
 - [x] Tray idle / listening / processing icons and full tray menu

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -242,6 +242,10 @@ struct Settings {
     /// `CustomVocabulary`, then sent to whisper.cpp as `initial_prompt`.
     #[serde(default)]
     custom_vocabulary: String,
+    /// VocaLinux `copy_to_clipboard`: leave the transcript on the clipboard.
+    /// Off by default so insertion does not take over whatever was copied.
+    #[serde(default)]
+    copy_to_clipboard: bool,
 }
 
 fn default_true() -> bool {
@@ -279,6 +283,7 @@ impl Default for Settings {
             history_enabled: true,
             debug_logging: false,
             custom_vocabulary: String::new(),
+            copy_to_clipboard: false,
         }
     }
 }
@@ -861,7 +866,7 @@ fn finish_captured_audio(app: &AppHandle, samples: Vec<f32>, sample_rate: u32) {
                 .lock()
                 .unwrap_or_else(|e| e.into_inner());
             if inject {
-                let _ = output::inject(&text);
+                let _ = inject_transcript(&*state, &text);
                 let _ = app.emit("dictation-finished", text);
             } else {
                 let _ = app.emit("test-dictation-finished", text);
@@ -2049,7 +2054,7 @@ fn finish_voice_session(handle: &AppHandle) {
         Ok(Some(text)) if !text.is_empty() => {
             sounds::play_if_enabled(&settings.sound_theme, false);
             if inject {
-                let _ = output::inject(&text);
+                let _ = inject_transcript(&*state, &text);
                 let _ = handle.emit("dictation-finished", text);
             } else {
                 let _ = handle.emit("test-dictation-finished", text);
@@ -2305,15 +2310,24 @@ fn list_running_apps() -> Vec<autopause::RunningApp> {
     autopause::list_running_apps()
 }
 
+fn inject_transcript(state: &AppState, text: &str) -> Result<(), String> {
+    let copy_to_clipboard = state
+        .settings
+        .lock()
+        .map(|settings| settings.copy_to_clipboard)
+        .unwrap_or(false);
+    output::inject(text, output::InjectOptions { copy_to_clipboard })
+}
+
 /// On Windows this is the final platform boundary: the recognizer gives us
 /// text, then the injector enters it at the focused application. It is kept
 /// separate from recognition so every engine gets identical insertion behavior.
 #[tauri::command]
-fn inject_text(text: String) -> Result<(), String> {
+fn inject_text(text: String, state: State<'_, AppState>) -> Result<(), String> {
     if text.trim().is_empty() {
         return Ok(());
     }
-    output::inject(&text)
+    inject_transcript(&*state, &text)
 }
 
 #[tauri::command]
@@ -2822,7 +2836,7 @@ fn tray_stop_voice(app: &AppHandle) -> Result<(), String> {
         Ok(text) => {
             sounds::play_if_enabled(&sound, false);
             if !text.is_empty() {
-                let _ = output::inject(&text);
+                let _ = inject_transcript(&*state, &text);
             }
             let _ = app.emit("dictation-finished", text);
             let _ = app.emit("recording-changed", false);
@@ -3036,6 +3050,19 @@ mod tests {
         let settings = Settings::default();
         assert!(settings.history_enabled);
         assert!(!settings.debug_logging);
+    }
+
+    #[test]
+    fn copy_to_clipboard_stays_off_by_default() {
+        assert!(!Settings::default().copy_to_clipboard);
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("legacy.json");
+        fs::write(
+            &path,
+            r#"{"hotkey":"AltRight","activationMode":"pushToTalk","language":"Auto-detect","silenceSeconds":1.5,"maxRecordingSeconds":60.0,"launchAtLogin":false,"soundEffects":true,"appendTrailingSpace":true,"autoCapitalize":true,"selectedModel":"whisper-tiny"}"#,
+        )
+        .unwrap();
+        assert!(!load_settings(&path).copy_to_clipboard);
     }
 
     #[test]

--- a/src-tauri/src/output.rs
+++ b/src-tauri/src/output.rs
@@ -133,7 +133,7 @@ fn inject_send_input(text: &str) -> Result<(), String> {
             continue;
         }
         let mut units = [0u16; 2];
-        for &unit in ch.encode_utf16(&mut units) {
+        for &unit in ch.encode_utf16(&mut units).iter() {
             inputs.extend([
                 INPUT {
                     r#type: INPUT_KEYBOARD,
@@ -383,7 +383,7 @@ fn write_clipboard_unicode(text: &str) -> Result<(), String> {
     use windows::core::HSTRING;
     use windows::Win32::Foundation::HANDLE;
     use windows::Win32::System::DataExchange::{CloseClipboard, EmptyClipboard, SetClipboardData};
-    use windows::Win32::System::Memory::{GlobalAlloc, GlobalFree, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+    use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
     let encoded: Vec<u16> = HSTRING::from(text).as_wide().iter().copied().chain([0]).collect();
     let bytes = encoded.len() * 2;
     unsafe {
@@ -391,13 +391,13 @@ fn write_clipboard_unicode(text: &str) -> Result<(), String> {
             .map_err(|error| format!("clipboard alloc failed: {error}"))?;
         let ptr = GlobalLock(mem) as *mut u16;
         if ptr.is_null() {
-            let _ = GlobalFree(mem);
+            global_free(mem);
             return Err("clipboard lock failed".into());
         }
         std::ptr::copy_nonoverlapping(encoded.as_ptr(), ptr, encoded.len());
         let _ = GlobalUnlock(mem);
         if let Err(error) = open_clipboard_with_retry() {
-            let _ = GlobalFree(mem);
+            global_free(mem);
             return Err(error);
         }
         let result = (|| {
@@ -408,10 +408,17 @@ fn write_clipboard_unicode(text: &str) -> Result<(), String> {
         })();
         let _ = CloseClipboard();
         if result.is_err() {
-            let _ = GlobalFree(mem);
+            global_free(mem);
         }
         result
     }
+}
+
+/// windows 0.58 exports GlobalFree from Foundation, not System::Memory.
+/// A successful free returns a null handle, which the crate reports as Err.
+#[cfg(windows)]
+unsafe fn global_free(mem: windows::Win32::Foundation::HGLOBAL) {
+    let _ = windows::Win32::Foundation::GlobalFree(mem);
 }
 
 #[cfg(windows)]
@@ -467,7 +474,7 @@ fn capture_clipboard_snapshot() -> Result<ClipboardSnapshot, String> {
 fn restore_clipboard_snapshot(snapshot: &ClipboardSnapshot) -> Result<(), String> {
     use windows::Win32::Foundation::HANDLE;
     use windows::Win32::System::DataExchange::{CloseClipboard, EmptyClipboard, SetClipboardData};
-    use windows::Win32::System::Memory::{GlobalAlloc, GlobalFree, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+    use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
     if snapshot.formats.is_empty() {
         return clear_clipboard();
     }
@@ -479,13 +486,13 @@ fn restore_clipboard_snapshot(snapshot: &ClipboardSnapshot) -> Result<(), String
                 .map_err(|error| format!("clipboard alloc failed: {error}"))?;
             let ptr = GlobalLock(mem) as *mut u8;
             if ptr.is_null() {
-                let _ = GlobalFree(mem);
+                global_free(mem);
                 return Err("clipboard lock failed".into());
             }
             std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len());
             let _ = GlobalUnlock(mem);
             if SetClipboardData(*format, HANDLE(mem.0)).is_err() {
-                let _ = GlobalFree(mem);
+                global_free(mem);
             }
         }
         Ok(())

--- a/src-tauri/src/output.rs
+++ b/src-tauri/src/output.rs
@@ -1,5 +1,10 @@
 //! Dictation output polish (parity with VocaMac DictationOutputFormatter)
-//! and Windows text injection with a clipboard paste fallback.
+//! and Windows text injection.
+//!
+//! Default insertion matches VocaMac (Accessibility first) and VocaLinux
+//! (IBus/wtype first): type into the focused window and leave the clipboard
+//! alone. Clipboard + Ctrl+V is the fallback, and that path restores the
+//! previous clipboard unless the user opts into copy-to-clipboard.
 
 pub fn append_trailing_space(text: &str) -> String {
     if text.is_empty() {
@@ -48,37 +53,88 @@ pub fn apply_output_polish(text: &str, auto_capitalize: bool, trailing_space: bo
     result
 }
 
-#[cfg(windows)]
-pub fn inject(text: &str) -> Result<(), String> {
+/// Controls whether dictation is also left on the system clipboard.
+///
+/// Matches VocaLinux `copy_to_clipboard` (default off) and VocaMac
+/// `preserveClipboard` (default on): do not take over the clipboard unless
+/// the user asks for it.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct InjectOptions {
+    pub copy_to_clipboard: bool,
+}
+
+impl InjectOptions {
+    pub fn restore_clipboard(self) -> bool {
+        !self.copy_to_clipboard
+    }
+}
+
+pub fn inject(text: &str, options: InjectOptions) -> Result<(), String> {
     if text.is_empty() {
         return Ok(());
     }
-    // Mac TextInjector path: clipboard + paste chord + restore. SendInput remains
-    // as a fallback when the clipboard path cannot run.
-    match inject_via_clipboard(text) {
+    #[cfg(windows)]
+    {
+        inject_windows(text, options)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = options;
+        Err("Text injection is available in Windows builds only.".into())
+    }
+}
+
+#[cfg(windows)]
+fn inject_windows(text: &str, options: InjectOptions) -> Result<(), String> {
+    // Prefer SendInput so the default path never opens the clipboard.
+    // Clipboard + Ctrl+V is the fallback (layout-independent, like VocaLinux
+    // ydotool paste) and restores the previous clipboard unless the user
+    // enabled copy-to-clipboard.
+    if options.copy_to_clipboard {
+        return match inject_via_clipboard(text, false) {
+            Ok(()) => Ok(()),
+            Err(clipboard_error) => inject_send_input(text)
+                .and_then(|_| write_clipboard_unicode(text))
+                .map_err(|send_input_error| {
+                    format!(
+                        "Clipboard paste failed ({clipboard_error}); SendInput also failed ({send_input_error})"
+                    )
+                }),
+        };
+    }
+    match inject_send_input(text) {
         Ok(()) => Ok(()),
-        Err(clipboard_error) => inject_send_input(text).map_err(|send_input_error| {
+        Err(send_input_error) => inject_via_clipboard(text, true).map_err(|clipboard_error| {
             format!(
-                "Clipboard paste failed ({clipboard_error}); SendInput also failed ({send_input_error})"
+                "SendInput failed ({send_input_error}); clipboard paste also failed ({clipboard_error})"
             )
         }),
     }
 }
 
-#[cfg(not(windows))]
-pub fn inject(_: &str) -> Result<(), String> {
-    Err("Text injection is available in Windows builds only.".into())
-}
-
 #[cfg(windows)]
 fn inject_send_input(text: &str) -> Result<(), String> {
     use windows::Win32::UI::Input::KeyboardAndMouse::{
-        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_UNICODE, VIRTUAL_KEY,
+        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP, KEYEVENTF_UNICODE,
+        VIRTUAL_KEY, VK_RETURN,
     };
-    let inputs: Vec<INPUT> = text
-        .encode_utf16()
-        .flat_map(|unit| {
-            [
+    let mut inputs: Vec<INPUT> = Vec::new();
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\r' {
+            if chars.peek() == Some(&'\n') {
+                let _ = chars.next();
+            }
+            inputs.extend([key_down(VK_RETURN), key_up(VK_RETURN)]);
+            continue;
+        }
+        if ch == '\n' {
+            inputs.extend([key_down(VK_RETURN), key_up(VK_RETURN)]);
+            continue;
+        }
+        let mut units = [0u16; 2];
+        for &unit in ch.encode_utf16(&mut units) {
+            inputs.extend([
                 INPUT {
                     r#type: INPUT_KEYBOARD,
                     Anonymous: INPUT_0 {
@@ -97,16 +153,15 @@ fn inject_send_input(text: &str) -> Result<(), String> {
                         ki: KEYBDINPUT {
                             wVk: VIRTUAL_KEY(0),
                             wScan: unit,
-                            dwFlags: KEYEVENTF_UNICODE
-                                | windows::Win32::UI::Input::KeyboardAndMouse::KEYEVENTF_KEYUP,
+                            dwFlags: KEYEVENTF_UNICODE | KEYEVENTF_KEYUP,
                             time: 0,
                             dwExtraInfo: 0,
                         },
                     },
                 },
-            ]
-        })
-        .collect();
+            ]);
+        }
+    }
     let sent = unsafe { SendInput(&inputs, std::mem::size_of::<INPUT>() as i32) };
     if sent as usize == inputs.len() {
         Ok(())
@@ -118,41 +173,72 @@ fn inject_send_input(text: &str) -> Result<(), String> {
 #[cfg(windows)]
 const CF_UNICODETEXT: u32 = 13;
 
+/// GDI clipboard formats that are not HGLOBAL and cannot be round-tripped
+/// with GetClipboardData/SetClipboardData the same way text can.
 #[cfg(windows)]
-fn inject_via_clipboard(text: &str) -> Result<(), String> {
-    use windows::core::HSTRING;
-    use windows::Win32::Foundation::{HANDLE, HWND};
-    use windows::Win32::System::DataExchange::{
-        CloseClipboard, EmptyClipboard, OpenClipboard, SetClipboardData,
-    };
-    use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+fn is_gdi_clipboard_format(format: u32) -> bool {
+    matches!(
+        format,
+        2 | 3 | 9 | 14 | 0x0080 | 0x0082 | 0x0083 | 0x008E
+    )
+}
+
+#[cfg(windows)]
+#[derive(Clone, Default)]
+struct ClipboardSnapshot {
+    formats: Vec<(u32, Vec<u8>)>,
+}
+
+#[cfg(windows)]
+#[derive(Clone)]
+enum PendingRestore {
+    Idle,
+    Snapshot(ClipboardSnapshot),
+    Failed,
+}
+
+#[cfg(windows)]
+struct ClipboardRestoreState {
+    generation: u64,
+    pending: PendingRestore,
+}
+
+#[cfg(windows)]
+fn clipboard_restore_state() -> &'static std::sync::Mutex<ClipboardRestoreState> {
+    static STATE: std::sync::OnceLock<std::sync::Mutex<ClipboardRestoreState>> =
+        std::sync::OnceLock::new();
+    STATE.get_or_init(|| {
+        std::sync::Mutex::new(ClipboardRestoreState {
+            generation: 0,
+            pending: PendingRestore::Idle,
+        })
+    })
+}
+
+#[cfg(windows)]
+fn inject_via_clipboard(text: &str, restore: bool) -> Result<(), String> {
     use windows::Win32::UI::Input::KeyboardAndMouse::{SendInput, INPUT, VK_CONTROL, VK_V};
 
-    // Preserve prior clipboard text when possible.
-    let previous = read_clipboard_unicode().ok();
-    let encoded: Vec<u16> = HSTRING::from(text).as_wide().iter().copied().chain([0]).collect();
-    let bytes = encoded.len() * 2;
-    unsafe {
-        let mem = GlobalAlloc(GMEM_MOVEABLE, bytes)
-            .map_err(|error| format!("clipboard alloc failed: {error}"))?;
-        let ptr = GlobalLock(mem) as *mut u16;
-        if ptr.is_null() {
-            return Err("clipboard lock failed".into());
+    let generation = {
+        let mut state = clipboard_restore_state()
+            .lock()
+            .map_err(|_| "clipboard restore lock poisoned")?;
+        state.generation = state.generation.wrapping_add(1);
+        if restore {
+            if matches!(state.pending, PendingRestore::Idle) {
+                state.pending = match capture_clipboard_snapshot() {
+                    Ok(snapshot) => PendingRestore::Snapshot(snapshot),
+                    Err(_) => PendingRestore::Failed,
+                };
+            }
+        } else {
+            state.pending = PendingRestore::Idle;
         }
-        std::ptr::copy_nonoverlapping(encoded.as_ptr(), ptr, encoded.len());
-        let _ = GlobalUnlock(mem);
-        OpenClipboard(HWND::default()).map_err(|error| format!("OpenClipboard: {error}"))?;
-        let result = (|| {
-            EmptyClipboard().map_err(|error| format!("EmptyClipboard: {error}"))?;
-            SetClipboardData(CF_UNICODETEXT, HANDLE(mem.0))
-                .map_err(|error| format!("SetClipboardData: {error}"))?;
-            Ok::<(), String>(())
-        })();
-        let _ = CloseClipboard();
-        result?;
-    }
+        state.generation
+    };
 
-    // Ctrl+V
+    write_clipboard_unicode(text)?;
+
     let inputs = [
         key_down(VK_CONTROL),
         key_down(VK_V),
@@ -161,14 +247,46 @@ fn inject_via_clipboard(text: &str) -> Result<(), String> {
     ];
     let sent = unsafe { SendInput(&inputs, std::mem::size_of::<INPUT>() as i32) };
     if sent as usize != inputs.len() {
+        if restore {
+            restore_pending_clipboard(generation, None);
+        }
         return Err("Ctrl+V SendInput failed".into());
     }
     // Match Mac TextInjector: give the target app time to consume Ctrl+V.
     std::thread::sleep(std::time::Duration::from_millis(150));
-    if let Some(previous) = previous {
-        let _ = write_clipboard_unicode(&previous);
+    if restore {
+        restore_pending_clipboard(generation, Some(text));
     }
     Ok(())
+}
+
+#[cfg(windows)]
+fn restore_pending_clipboard(generation: u64, expected_text: Option<&str>) {
+    let pending = {
+        let Ok(mut state) = clipboard_restore_state().lock() else {
+            return;
+        };
+        if state.generation != generation {
+            return;
+        }
+        std::mem::replace(&mut state.pending, PendingRestore::Idle)
+    };
+    // VocaLinux: if the user (or a clipboard manager) replaced our
+    // transcription during the delay, leave that newer value alone.
+    if let Some(text) = expected_text {
+        if !clipboard_unicode_equals(text) {
+            return;
+        }
+    }
+    match pending {
+        PendingRestore::Snapshot(snapshot) if snapshot.formats.is_empty() => {
+            let _ = clear_clipboard();
+        }
+        PendingRestore::Snapshot(snapshot) => {
+            let _ = restore_clipboard_snapshot(&snapshot);
+        }
+        PendingRestore::Failed | PendingRestore::Idle => {}
+    }
 }
 
 #[cfg(windows)]
@@ -208,19 +326,36 @@ fn key_up(vk: windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY) -> windo
 }
 
 #[cfg(windows)]
-fn read_clipboard_unicode() -> Result<String, String> {
+fn open_clipboard_with_retry() -> Result<(), String> {
     use windows::Win32::Foundation::HWND;
+    use windows::Win32::System::DataExchange::OpenClipboard;
+    for _ in 0..10 {
+        if unsafe { OpenClipboard(HWND::default()) }.is_ok() {
+            return Ok(());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    Err("OpenClipboard: busy".into())
+}
+
+#[cfg(windows)]
+fn read_clipboard_unicode() -> Result<String, String> {
     use windows::Win32::System::DataExchange::{
-        CloseClipboard, GetClipboardData, IsClipboardFormatAvailable, OpenClipboard,
+        CloseClipboard, GetClipboardData, IsClipboardFormatAvailable,
     };
     use windows::Win32::System::Memory::{GlobalLock, GlobalUnlock};
     unsafe {
         if IsClipboardFormatAvailable(CF_UNICODETEXT).is_err() {
             return Err("no unicode clipboard".into());
         }
-        OpenClipboard(HWND::default()).map_err(|error| format!("OpenClipboard: {error}"))?;
-        let handle = GetClipboardData(CF_UNICODETEXT)
-            .map_err(|error| format!("GetClipboardData: {error}"))?;
+        open_clipboard_with_retry()?;
+        let handle = match GetClipboardData(CF_UNICODETEXT) {
+            Ok(handle) => handle,
+            Err(error) => {
+                let _ = CloseClipboard();
+                return Err(format!("GetClipboardData: {error}"));
+            }
+        };
         let ptr = GlobalLock(windows::Win32::Foundation::HGLOBAL(handle.0)) as *const u16;
         if ptr.is_null() {
             let _ = CloseClipboard();
@@ -239,13 +374,16 @@ fn read_clipboard_unicode() -> Result<String, String> {
 }
 
 #[cfg(windows)]
+fn clipboard_unicode_equals(text: &str) -> bool {
+    read_clipboard_unicode().is_ok_and(|current| current == text)
+}
+
+#[cfg(windows)]
 fn write_clipboard_unicode(text: &str) -> Result<(), String> {
     use windows::core::HSTRING;
-    use windows::Win32::Foundation::{HANDLE, HWND};
-    use windows::Win32::System::DataExchange::{
-        CloseClipboard, EmptyClipboard, OpenClipboard, SetClipboardData,
-    };
-    use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::System::DataExchange::{CloseClipboard, EmptyClipboard, SetClipboardData};
+    use windows::Win32::System::Memory::{GlobalAlloc, GlobalFree, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
     let encoded: Vec<u16> = HSTRING::from(text).as_wide().iter().copied().chain([0]).collect();
     let bytes = encoded.len() * 2;
     unsafe {
@@ -253,11 +391,15 @@ fn write_clipboard_unicode(text: &str) -> Result<(), String> {
             .map_err(|error| format!("clipboard alloc failed: {error}"))?;
         let ptr = GlobalLock(mem) as *mut u16;
         if ptr.is_null() {
+            let _ = GlobalFree(mem);
             return Err("clipboard lock failed".into());
         }
         std::ptr::copy_nonoverlapping(encoded.as_ptr(), ptr, encoded.len());
         let _ = GlobalUnlock(mem);
-        OpenClipboard(HWND::default()).map_err(|error| format!("OpenClipboard: {error}"))?;
+        if let Err(error) = open_clipboard_with_retry() {
+            let _ = GlobalFree(mem);
+            return Err(error);
+        }
         let result = (|| {
             EmptyClipboard().map_err(|error| format!("EmptyClipboard: {error}"))?;
             SetClipboardData(CF_UNICODETEXT, HANDLE(mem.0))
@@ -265,8 +407,91 @@ fn write_clipboard_unicode(text: &str) -> Result<(), String> {
             Ok::<(), String>(())
         })();
         let _ = CloseClipboard();
+        if result.is_err() {
+            let _ = GlobalFree(mem);
+        }
         result
     }
+}
+
+#[cfg(windows)]
+fn clear_clipboard() -> Result<(), String> {
+    use windows::Win32::System::DataExchange::{CloseClipboard, EmptyClipboard};
+    open_clipboard_with_retry()?;
+    let result = unsafe { EmptyClipboard() }.map_err(|error| format!("EmptyClipboard: {error}"));
+    let _ = unsafe { CloseClipboard() };
+    result.map(|_| ())
+}
+
+#[cfg(windows)]
+fn capture_clipboard_snapshot() -> Result<ClipboardSnapshot, String> {
+    use windows::Win32::System::DataExchange::{
+        CloseClipboard, EnumClipboardFormats, GetClipboardData,
+    };
+    use windows::Win32::System::Memory::{GlobalLock, GlobalSize, GlobalUnlock};
+    open_clipboard_with_retry()?;
+    let result = (|| unsafe {
+        let mut snapshot = ClipboardSnapshot::default();
+        let mut format = 0u32;
+        loop {
+            format = EnumClipboardFormats(format);
+            if format == 0 {
+                break;
+            }
+            if is_gdi_clipboard_format(format) {
+                continue;
+            }
+            let Ok(handle) = GetClipboardData(format) else {
+                continue;
+            };
+            let mem = windows::Win32::Foundation::HGLOBAL(handle.0);
+            let size = GlobalSize(mem);
+            if size == 0 {
+                continue;
+            }
+            let ptr = GlobalLock(mem) as *const u8;
+            if ptr.is_null() {
+                continue;
+            }
+            let bytes = std::slice::from_raw_parts(ptr, size).to_vec();
+            let _ = GlobalUnlock(mem);
+            snapshot.formats.push((format, bytes));
+        }
+        Ok(snapshot)
+    })();
+    let _ = unsafe { CloseClipboard() };
+    result
+}
+
+#[cfg(windows)]
+fn restore_clipboard_snapshot(snapshot: &ClipboardSnapshot) -> Result<(), String> {
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::System::DataExchange::{CloseClipboard, EmptyClipboard, SetClipboardData};
+    use windows::Win32::System::Memory::{GlobalAlloc, GlobalFree, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+    if snapshot.formats.is_empty() {
+        return clear_clipboard();
+    }
+    open_clipboard_with_retry()?;
+    let result = (|| unsafe {
+        EmptyClipboard().map_err(|error| format!("EmptyClipboard: {error}"))?;
+        for (format, bytes) in &snapshot.formats {
+            let mem = GlobalAlloc(GMEM_MOVEABLE, bytes.len())
+                .map_err(|error| format!("clipboard alloc failed: {error}"))?;
+            let ptr = GlobalLock(mem) as *mut u8;
+            if ptr.is_null() {
+                let _ = GlobalFree(mem);
+                return Err("clipboard lock failed".into());
+            }
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len());
+            let _ = GlobalUnlock(mem);
+            if SetClipboardData(*format, HANDLE(mem.0)).is_err() {
+                let _ = GlobalFree(mem);
+            }
+        }
+        Ok(())
+    })();
+    let _ = unsafe { CloseClipboard() };
+    result
 }
 
 /// Copy Debug log text (and other UI strings) to the system clipboard.
@@ -307,5 +532,20 @@ mod tests {
             apply_output_polish("hello. world", true, true),
             "Hello. World "
         );
+    }
+
+    #[test]
+    fn clipboard_is_not_taken_over_by_default() {
+        let options = InjectOptions::default();
+        assert!(!options.copy_to_clipboard);
+        assert!(options.restore_clipboard());
+    }
+
+    #[test]
+    fn copy_to_clipboard_skips_restore() {
+        let options = InjectOptions {
+            copy_to_clipboard: true,
+        };
+        assert!(!options.restore_clipboard());
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ type Settings = {
   historyEnabled: boolean;
   debugLogging: boolean;
   customVocabulary: string;
+  copyToClipboard: boolean;
 };
 type View = "dictation" | "models" | "history" | "settings" | "debug" | "about";
 type HistoryEntry = { id: number; text: string; modelId: string; createdAtMs: number };
@@ -610,6 +611,13 @@ function settingsItems(): SettingsItem[] {
     },
     {
       group: "Dictation",
+      title: "Copy to clipboard",
+      subtitle: "Leave recognized text on the clipboard after each take. Off by default so dictation does not replace what you already copied.",
+      keywords: "clipboard paste preserve copy output",
+      html: `<label class="switch"><input id="copy-to-clipboard" type="checkbox" ${settings.copyToClipboard ? "checked" : ""}/><span></span></label>`,
+    },
+    {
+      group: "Dictation",
       title: "Custom Vocabulary",
       subtitle: "Bias Whisper toward names and jargon. It is a hint, not a guarantee.",
       keywords: "custom vocabulary dictionary glossary names jargon initial prompt whisper",
@@ -995,6 +1003,8 @@ function collectSettingsFromDom() {
   if (autoCap) settings.autoCapitalize = autoCap.checked;
   const trailing = document.querySelector<HTMLInputElement>("#trailing-space");
   if (trailing) settings.appendTrailingSpace = trailing.checked;
+  const copyToClipboard = document.querySelector<HTMLInputElement>("#copy-to-clipboard");
+  if (copyToClipboard) settings.copyToClipboard = copyToClipboard.checked;
   const launch = document.querySelector<HTMLInputElement>("#launch-login");
   if (launch) settings.launchAtLogin = launch.checked;
   const inputDevice = document.querySelector<HTMLSelectElement>("#input-device");
@@ -1445,6 +1455,7 @@ Promise.all([
     historyEnabled: saved.historyEnabled ?? true,
     debugLogging: saved.debugLogging ?? false,
     customVocabulary: saved.customVocabulary ?? "",
+    copyToClipboard: saved.copyToClipboard ?? false,
   };
   statuses = installs;
   history = entries;


### PR DESCRIPTION
## Why

Windows insertion always went through the clipboard (`EmptyClipboard` + Ctrl+V). That replaced whatever the user had copied, including when the previous clipboard was empty or not unicode text, because restore only ran if a unicode snapshot existed.

VocaMac inserts via Accessibility first (clipboard untouched) and only pastes as a fallback, with `preserveClipboard` defaulting to on. VocaLinux inserts via IBus/wtype first, restores after a clipboard paste, and keeps `copy_to_clipboard` off by default.

## What

- Default path is `SendInput` so dictation does not open the clipboard.
- Clipboard + Ctrl+V is the fallback. That path snapshots clipboard formats, pastes, then restores (or clears, if the clipboard was empty). Overlapping pastes share the original snapshot. A newer clipboard value during the restore delay is left alone.
- New Settings toggle **Copy to clipboard**, off by default (VocaLinux parity). When on, the transcript is left on the clipboard.

The linked vocalinux #725 is a number-row request and is not related to this change.