### PR TITLE
Call VocaWin a beta

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,6 @@
 # Moving GitHub Release tagged `nightly` for testers who want today's main.
-# Does not replace the v* alpha. windows-alpha-release.yml still owns tagged cuts.
-# Tag name is `nightly`, not v*, so it cannot fire the alpha workflow.
+# Does not replace the last tagged tester cut. windows-alpha-release.yml still owns v* tags.
+# Tag name is `nightly`, not v*, so it cannot fire the tagged prerelease workflow.
 # Installers stay unsigned. SmartScreen is expected.
 
 name: Nightly
@@ -174,11 +174,11 @@ jobs:
           $sums = (Get-Content nightly-out\checksums.txt -Raw).Trim()
           $fence = '```'
           $notes = @(
-            "Unsigned installer from ``main`` @ ``$($env:SHORT_SHA)``. This is not the tagged alpha.",
+            "Unsigned installer from ``main`` @ ``$($env:SHORT_SHA)``. This is not the last tagged tester cut.",
             "",
             "Windows will likely say the publisher is unknown. That is SmartScreen. More info, then Run anyway if you trust the file. There is no store signature and no auto-update.",
             "",
-            "Prefer the latest ``v*`` alpha if you want the last cut we named. Use nightly if you want today's tree.",
+            "Prefer the latest tagged Release if you want the last cut we named. Use nightly if you want today's tree.",
             "",
             "## Install",
             "",

--- a/.github/workflows/windows-alpha-release.yml
+++ b/.github/workflows/windows-alpha-release.yml
@@ -1,4 +1,4 @@
-# Windows alpha for testers. Unsigned installers.
+# Windows tagged prerelease for testers. Unsigned installers.
 # Not a purchased CA / store build. vocawin.com points at GitHub Releases.
 #
 # Tag push is the only trigger. windows-ci.yml must never set tagName.
@@ -8,7 +8,7 @@
 # No workflow_dispatch, so a branch click cannot publish.
 # includeUpdaterJson is off so we do not upload latest.json.
 
-name: Windows alpha release
+name: Windows tagged prerelease
 
 on:
   push:
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   release:
-    name: Windows alpha installers
+    name: Windows tagged installers
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-latest
     permissions:
@@ -70,9 +70,9 @@ jobs:
           CMAKE_GENERATOR: Ninja
         with:
           tagName: ${{ github.ref_name }}
-          releaseName: VocaWin ${{ github.ref_name }} (Windows alpha)
+          releaseName: VocaWin ${{ github.ref_name }} (Windows beta)
           releaseBody: |
-            This is a Windows alpha for testers. vocawin.com points at GitHub Releases. It is not a store build and not a stable public ship.
+            This is a Windows beta for testers. vocawin.com points at GitHub Releases. It is not a store build and not a stable public ship.
 
             The installers are unsigned. Windows will say the publisher is unknown. That is expected. More info, then Run anyway if you trust the file.
           releaseDraft: false

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -103,7 +103,7 @@ jobs:
         run: cargo test --manifest-path src-tauri/Cargo.toml
 
   installer:
-    name: Windows installer (alpha)
+    name: Windows installer (beta)
     needs: changes
     # PRs never package. Main packages only when app/workflow source
     # changed. workflow_dispatch still builds test + installer.
@@ -148,7 +148,7 @@ jobs:
           CARGO_TARGET_DIR: C:\t
           CMAKE_GENERATOR: Ninja
         with:
-          # Build only. Do not set tagName. Tagged alpha Releases live in
+          # Build only. Do not set tagName. Tagged beta Releases live in
           # windows-alpha-release.yml. The moving nightly Release lives in
           # nightly.yml. This job stays artifact-only.
           args: --bundles nsis,msi
@@ -158,10 +158,10 @@ jobs:
       #   C:\t\release\bundle\msi\VocaWin_*_x64_en-US.msi
       # Confirmed on the 2026-08-18 installer job (run 32196306136).
       # Installers stay unsigned. Self-sign hung on Authenticode timestamps.
-      - name: Upload Windows alpha installers
+      - name: Upload Windows beta installers
         uses: actions/upload-artifact@v4
         with:
-          name: VocaWin-windows-alpha
+          name: VocaWin-windows-beta
           path: |
             C:/t/release/bundle/nsis/*-setup.exe
             C:/t/release/bundle/msi/*.msi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Instructions for coding agents on **VocaWin** (`VocaHQ/vocawin`). Default branch
 
 Native Windows voice typing: hold a hotkey, speak, text at the caret. After a Whisper or ONNX model is on disk, capture and transcription stay on this PC. No Voca account, no hosted speech API, no product telemetry, no gateway mode.
 
-This is a **developer alpha**. Installers are **unsigned**. Do not call it signed, Store-ready, stable, or a public ship.
+This is a **beta**. Installers are **unsigned**. Do not call it signed, Store-ready, stable, or a public ship.
 
 ## Critical: git worktrees for every branch and PR
 
@@ -53,7 +53,7 @@ Rust modules (keep work in the matching file):
 
 Windows builds enable `whisper-rs` **Vulkan** and `transcribe-rs` **DirectML**. Non-Windows keeps CPU-only whisper so `cargo test` still runs. `build.rs` sets `cfg(vocawin_whisper_vulkan)` only for Windows targets — catalog strings must match that cfg.
 
-App data: `%APPDATA%\com.vocahq.vocawin\` (`settings.json`, `history.json`, `models/`). Window title says Alpha. Close hides to tray; Quit is tray-only. Autostart uses `--start-minimized`.
+App data: `%APPDATA%\com.vocahq.vocawin\` (`settings.json`, `history.json`, `models/`). Window title says Beta. Close hides to tray; Quit is tray-only. Autostart uses `--start-minimized`.
 
 ## Commands
 
@@ -116,7 +116,7 @@ Do not add a frontend framework. Add Tauri commands next to the existing `invoke
 
 ## Releases and CI
 
-App version stays **`0.1.0`** in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` across alphas. The Git tag is the public version. Do not bump the app version for an alpha or a nightly. Do not pin a `v*` tag in README or on vocawin.com.
+App version stays **`0.1.0`** in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` across betas. The Git tag is the public version. Do not bump the app version for a beta or a nightly. Do not pin a `v*` tag in README or on vocawin.com.
 
 | Workflow | Trigger | Effect |
 | --- | --- | --- |
@@ -125,13 +125,13 @@ App version stays **`0.1.0`** in `package.json`, `src-tauri/Cargo.toml`, and `sr
 | `nightly.yml` | cron + dispatch | Moving `nightly` prerelease from `main` when app source changed. Not a `v*` tag. |
 | `deploy-pages.yml` | `web/**` on `main` | Publishes vocawin.com. |
 
-Named tester cuts: `v0.1.0-alpha.N` via `RELEASE.md`. Testers use GitHub Releases, not the CI artifact. NSIS is current-user; MSI is the WiX wizard — one installer per PC, not both.
+Named tester cuts: `v0.1.0-beta.N` via `RELEASE.md`. Testers use GitHub Releases, not the CI artifact. NSIS is current-user; MSI is the WiX wizard. Use one installer per PC, not both.
 
-Do not set `tagName` in `windows-ci.yml`. Do not enable an updater. Do not retag. Nightly may be dispatched; a named alpha must not.
+Do not set `tagName` in `windows-ci.yml`. Do not enable an updater. Do not retag. Nightly may be dispatched; a named beta must not be cut from a branch click.
 
 ## Website (`web/`)
 
-Static HTML/CSS/JS. Hero download goes to `/releases`, with a quieter nightly link. `web/tests/site.test.mjs` enforces honesty: developer alpha, unsigned, SmartScreen, no `v*` pin, no “coming soon”, no telemetry snippets, AGPL-3.0-or-later.
+Static HTML/CSS/JS. Hero download goes to `/releases`, with a quieter nightly link. `web/tests/site.test.mjs` enforces honesty: beta, unsigned, SmartScreen, no `v*` pin, no "coming soon", no telemetry snippets, AGPL-3.0-or-later.
 
 If you change landing copy, run `node --test tests/site.test.mjs` from `web/`. Do not edit the VocaHQ directory repo from here.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Release](https://img.shields.io/github/v/release/VocaHQ/vocawin?include_prereleases&sort=semver)](https://github.com/VocaHQ/vocawin/releases)
 [![Nightly](https://img.shields.io/badge/Nightly-download-blueviolet)](https://github.com/VocaHQ/vocawin/releases/tag/nightly)
-[![Status](https://img.shields.io/badge/status-developer%20alpha-yellow)](#development)
+[![Status](https://img.shields.io/badge/status-beta-yellow)](#development)
 [![Platform](https://img.shields.io/badge/platform-Windows%2010%2F11-lightgrey)](#system-requirements)
 [![Privacy](https://img.shields.io/badge/privacy-on%20this%20PC-success)](#key-principles)
 
@@ -20,7 +20,7 @@
 [![Follow us](https://img.shields.io/badge/Follow%20us-000000?logo=x&logoColor=white)](https://x.com/vocahq)
 [![VocaHQ](https://img.shields.io/badge/VocaHQ-vocahq.com-1a7f4e)](https://vocahq.com)
 
-Developer alpha. Unsigned. Testers can grab a build from [GitHub Releases](https://github.com/VocaHQ/vocawin/releases). This is not a signed store build and not a stable public release.
+Beta. Unsigned. Testers can grab a build from [GitHub Releases](https://github.com/VocaHQ/vocawin/releases). This is not a signed store build and not a stable public release.
 
 </div>
 
@@ -39,13 +39,13 @@ It sits next to [VocaLinux](https://vocalinux.com), [VocaMac](https://vocamac.co
 - **Open source** - The repository is public
 - **No telemetry in the product** - The app does not phone home
 - **Windows native** - Tray app, hotkey, WASAPI, text at the caret
-- **Honest status** - Developer alpha. Unsigned. Windows will likely say the publisher is unknown.
+- **Honest status** - Beta. Unsigned. Windows will likely say the publisher is unknown.
 
 ## Try it
 
-Testers can install an unsigned developer alpha today. Download the NSIS `.exe` or the MSI from [GitHub Releases](https://github.com/VocaHQ/vocawin/releases). Windows will likely say the publisher is unknown. That is SmartScreen. More info, then Run anyway if you trust the file. Read [the setup guide](docs/setup.md) first.
+Testers can install an unsigned beta today. Download the NSIS `.exe` or the MSI from [GitHub Releases](https://github.com/VocaHQ/vocawin/releases). Windows will likely say the publisher is unknown. That is SmartScreen. More info, then Run anyway if you trust the file. Read [the setup guide](docs/setup.md) first.
 
-Want today's `main` instead of the last tagged alpha? Use the [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly). Same unsigned NSIS and MSI, rebuilt when app source on `main` changes. Prefer the tagged alpha if you want the last cut we named.
+Want today's `main` instead of the last tagged Release? Use the [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly). Same unsigned NSIS and MSI, rebuilt when app source on `main` changes. Prefer the latest tagged Release if you want the last cut we named.
 
 This is a tester build you can run today. It is not a store listing and not a stable public release.
 
@@ -109,7 +109,7 @@ Same privacy bar, different machines. Start at [vocahq.com](https://vocahq.com) 
 | Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [VocaHQ/vocalinux](https://github.com/VocaHQ/vocalinux) | Available |
 | macOS | **VocaMac** | [vocamac.com](https://vocamac.com) | [VocaHQ/vocamac](https://github.com/VocaHQ/vocamac) | Beta |
 | iPhone / Android | **VocaPhone** | [vocaphone.vocahq.com](https://vocaphone.vocahq.com) | [VocaHQ/vocaphone](https://github.com/VocaHQ/vocaphone) | Beta / source build |
-| Windows | **VocaWin** | [vocawin.com](https://vocawin.com) | [VocaHQ/vocawin](https://github.com/VocaHQ/vocawin) | Developer alpha |
+| Windows | **VocaWin** | [vocawin.com](https://vocawin.com) | [VocaHQ/vocawin](https://github.com/VocaHQ/vocawin) | Beta |
 | Infrastructure | **VocaGateway** | | [VocaHQ/vocagateway](https://github.com/VocaHQ/vocagateway) | Early |
 
 VocaGateway is optional self-hosted compute for other Voca clients. VocaWin does not expose a gateway mode today.
@@ -159,7 +159,7 @@ GitHub Actions publishes `web/` on pushes to `main`. The `web/CNAME` file maps `
 
 ## Contributing
 
-VocaWin is in early development. Download the unsigned alpha from [Releases](https://github.com/VocaHQ/vocawin/releases) if you want to try it. File bugs on [Issues](https://github.com/VocaHQ/vocawin/issues). The family directory is [vocahq.com](https://vocahq.com).
+VocaWin is in early development. Download the unsigned beta from [Releases](https://github.com/VocaHQ/vocawin/releases) if you want to try it. File bugs on [Issues](https://github.com/VocaHQ/vocawin/issues). The family directory is [vocahq.com](https://vocahq.com).
 
 ## Project references
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,20 +1,20 @@
-# Cutting a Windows alpha
+# Cutting a Windows beta
 
-This is the checklist we already use. A `v*` tag is what ships a **named** tester alpha. Nightlies are a second path: `.github/workflows/nightly.yml` publishes a moving `nightly` prerelease from `main` when app source changed. Do not use a `v*` tag for a nightly. Do not retag `nightly` by hand unless you are replacing a broken publish.
+This is the checklist we already use. A `v*` tag is what ships a **named** tester cut. Nightlies are a second path: `.github/workflows/nightly.yml` publishes a moving `nightly` prerelease from `main` when app source changed. Do not use a `v*` tag for a nightly. Do not retag `nightly` by hand unless you are replacing a broken publish.
 
 ## Tag
 
-The next alpha is the next `v0.1.0-alpha.N` after the current GitHub Release. Today that is `v0.1.0-alpha.3`, so the next tag is `v0.1.0-alpha.4` unless Jatin picks another name. Tag the commit you want testers to run, then push it. That is the only trigger.
+The next named tester tag is `v0.1.0-beta.1`. Cut it only after Jatin asks. The latest tagged Release today is still `v0.1.0-alpha.3`. Do not treat `v0.1.0-beta.1` as live until that tag is pushed. Tag the commit you want testers to run, then push it. That is the only trigger.
 
-`package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` stay at `0.1.0` across these alphas. The installers keep the `VocaWin_0.1.0_*` filenames. The Git tag is the public version. Do not bump the app version for an alpha.
+`package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` stay at `0.1.0` across these cuts. The installers keep the `VocaWin_0.1.0_*` filenames. The Git tag is the public version. Do not bump the app version for a beta.
 
 Do not retag. Do not use workflow_dispatch. `.github/workflows/windows-alpha-release.yml` has no manual trigger on purpose, so a branch click cannot publish.
 
 ## What CI does
 
-A `v*` tag push runs `windows-alpha-release.yml`. tauri-action builds unsigned NSIS and MSI and attaches them to a GitHub Release named `VocaWin <tag> (Windows alpha)`. The Release is always a prerelease. `includeUpdaterJson` stays off. There is no store signature and no auto-update.
+A `v*` tag push runs `windows-alpha-release.yml`. tauri-action builds unsigned NSIS and MSI and attaches them to a GitHub Release named `VocaWin <tag> (Windows beta)`. The Release is always a prerelease. `includeUpdaterJson` stays off. There is no store signature and no auto-update.
 
-`windows-ci.yml` on main still uploads a workflow artifact. Testers should ignore that and use a GitHub Release: the tagged `v*` alpha, or [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly) if they want today's `main`.
+`windows-ci.yml` on main still uploads a workflow artifact. Testers should ignore that and use a GitHub Release: the latest tagged `v*` cut, or [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly) if they want today's `main`.
 
 The nightly Release is always a prerelease named `nightly`. It is deleted and recreated; the URL stays the same. The README release badge uses `sort=semver` so `nightly` does not steal it from `v*`.
 
@@ -30,17 +30,17 @@ Upload a real Ready-screen shot as a release asset (alpha.2 used `vocawin-ready.
 ![VocaWin Ready](https://github.com/VocaHQ/vocawin/releases/download/<tag>/vocawin-ready.png)
 ```
 
-You can rename the Release to drop the `v` and the `(Windows alpha)` suffix. That is what we did on alpha.2 and alpha.3.
+You can rename the Release to drop the `v` and the `(Windows beta)` suffix. That is what we did on alpha.2 and alpha.3.
 
 ## Public pages
 
-[vocawin.com](https://vocawin.com) lives in `web/` and publishes from `main` when `web/` changes. The hero download still goes to [Releases](https://github.com/VocaHQ/vocawin/releases), not a `v*` tag. A quieter [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly) link is allowed because that tag is moving, not a version pin. Do not pin `v0.1.0-alpha.N` in the hero, the FAQ, or JSON-LD. Check the live page still says developer alpha, unsigned, More info then Run anyway.
+[vocawin.com](https://vocawin.com) lives in `web/` and publishes from `main` when `web/` changes. The hero download still goes to [Releases](https://github.com/VocaHQ/vocawin/releases), not a `v*` tag. A quieter [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly) link is allowed because that tag is moving, not a version pin. Do not pin `v0.1.0-beta.1` or any other `v*` tag in the hero, the FAQ, or JSON-LD. Check the live page still says beta, unsigned, More info then Run anyway.
 
 The README badge is `github/v/release` with `include_prereleases`. It tracks the latest prerelease by itself. Leave it pointed at `/releases`. Do not pin a tag in the README.
 
 `docs/setup.md` already points at `/releases`. Leave it that way.
 
-Glance at the GitHub repo description. It should say developer alpha and GitHub Releases, not Coming soon.
+Glance at the GitHub repo description. It should say beta and GitHub Releases, not Coming soon.
 
 The OG source under `web/assets/og/src` still says Coming soon. That is design art, not a tag you rewrite on every cut. Leave it unless VocaDesign replaces it.
 
@@ -50,4 +50,4 @@ VocaHQ owns vocahq.com and the family PRODUCT.md. If that page still lists an ol
 
 ## What not to do
 
-Do not pin a `v*` tag in the README or on vocawin.com. Do not bump the `0.1.0` app version for an alpha or a nightly. Do not tell testers the build is signed, Coming soon, or Available now. Do not cut an alpha from a branch click. Nightly may be dispatched by hand.
+Do not pin a `v*` tag in the README or on vocawin.com. Do not bump the `0.1.0` app version for a beta or a nightly. Do not tell testers the build is signed, Coming soon, or Available now. Do not cut a named beta from a branch click. Nightly may be dispatched by hand.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -35,7 +35,7 @@ This checklist tracks the path from the current local-recognition foundation to 
 
 - [x] Settings persistence and NSIS/MSI Tauri configuration
 - [x] Windows CI compilation job (Vulkan SDK + Ninja generator for whisper-rs)
-- [x] NSIS/MSI installer artifact job (alpha/dev; main/workflow_dispatch only, PRs cargo-test)
+- [x] NSIS/MSI installer artifact job (prerelease; main/workflow_dispatch only, PRs cargo-test)
 - [x] Tag-triggered GitHub Release for testers (`v*` tags, always prerelease)
 - [x] Official Voca mic app/tray icons (brand book §9 / §10)
 - [x] System tray menu: Start/Stop Voice Typing, Start on Login, Settings, Debug, About, Quit

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,8 +1,8 @@
 # Setup guide
 
-This is the tester page for the VocaWin alpha. [vocawin.com](https://vocawin.com) points testers at [GitHub Releases](https://github.com/VocaHQ/vocawin/releases). There is no Voca account and no hosted speech API.
+This is the tester page for the VocaWin beta. [vocawin.com](https://vocawin.com) points testers at [GitHub Releases](https://github.com/VocaHQ/vocawin/releases). There is no Voca account and no hosted speech API.
 
-The tagged alpha is the last cut we named. If you want today's `main`, use the [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly). Same unsigned NSIS and MSI. Say it is a nightly and include the commit from that Release if you file an issue.
+The latest tagged Release is the last cut we named. If you want today's `main`, use the [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly). Same unsigned NSIS and MSI. Say it is a nightly and include the commit from that Release if you file an issue.
 
 The NSIS and MSI are unsigned. That is not a store signature. Windows will likely say the publisher is unknown. That is SmartScreen. Use More info, then Run anyway, only if you trust the GitHub Release you downloaded.
 
@@ -14,6 +14,6 @@ Hold Right Alt to dictate, the same hold-default as VocaLinux. AltGr is left alo
 
 The tray mic is teal when idle, red while you speak, amber while a take is processing, and slate when the model is unloaded or paused.
 
-The window title and the sidebar pill say Alpha. That means this is a tester build, not a store ship.
+The window title and the sidebar pill say Beta. That means this is a tester build, not a store ship.
 
 Logs live in the Debug page, also available from the tray. Warning and error show by default. Debug logging is off until you turn it on. Copy and Clear work on the in-memory buffer. Clear does not delete files on disk. Settings and models sit under `%APPDATA%\com.vocahq.vocawin`.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,7 +10,7 @@
     "frontendDist": "../dist"
   },
   "app": {
-    "windows": [{"label":"main","title":"VocaWin · Alpha","width":1060,"height":700,"minWidth":840,"minHeight":580}],
+    "windows": [{"label":"main","title":"VocaWin · Beta","width":1060,"height":700,"minWidth":840,"minHeight":580}],
     "security": {"csp": "default-src 'self'; style-src 'self' 'unsafe-inline';"}
   },
   "bundle": {

--- a/src-tauri/windows/nsis-hooks.nsh
+++ b/src-tauri/windows/nsis-hooks.nsh
@@ -2,7 +2,7 @@
 ; Defines here stick, so we can brand welcome/finish without forking the template.
 
 !define MUI_WELCOMEPAGE_TITLE "VocaWin"
-!define MUI_WELCOMEPAGE_TEXT "This setup puts VocaWin on this PC. Hold a hotkey, speak, and text is meant to land at your cursor. After you download a speech-to-text model, dictation stays on this computer. This build is an unsigned alpha. vocawin.com is still Coming soon."
+!define MUI_WELCOMEPAGE_TEXT "This setup puts VocaWin on this PC. Hold a hotkey, speak, and text is meant to land at your cursor. After you download a speech-to-text model, dictation stays on this computer. This build is an unsigned beta. vocawin.com is live and points testers at GitHub Releases."
 
 !define MUI_FINISHPAGE_TITLE "VocaWin is installed."
 !define MUI_FINISHPAGE_TEXT "The first run will ask you to download a model. That uses the network once. After that, audio stays on this PC."

--- a/src-tauri/windows/wix-en-us.wxl
+++ b/src-tauri/windows/wix-en-us.wxl
@@ -5,7 +5,7 @@
   <String Id="PathEnvVarFeature">Add the VocaWin install folder to PATH so you can run it from a terminal.</String>
   <String Id="InstallAppFeature">Installs VocaWin.</String>
   <String Id="WelcomeDlgTitle">{\WixUI_Font_Bigger}VocaWin</String>
-  <String Id="WelcomeDlgDescription">This setup puts VocaWin on this PC. Hold a hotkey, speak, and text is meant to land at your cursor. After you download a speech-to-text model, dictation stays on this computer. This build is an unsigned alpha. vocawin.com is still Coming soon.</String>
+  <String Id="WelcomeDlgDescription">This setup puts VocaWin on this PC. Hold a hotkey, speak, and text is meant to land at your cursor. After you download a speech-to-text model, dictation stays on this computer. This build is an unsigned beta. vocawin.com is live and points testers at GitHub Releases.</String>
   <String Id="ExitDialogTitle">{\WixUI_Font_Bigger}VocaWin is installed.</String>
   <String Id="ExitDialogDescription">The first run will ask you to download a model. That uses the network once. After that, audio stays on this PC. Open the setup guide at https://github.com/VocaHQ/vocawin/blob/main/docs/setup.md</String>
 </WixLocalization>

--- a/src/main.ts
+++ b/src/main.ts
@@ -714,7 +714,7 @@ function debugPage() {
 }
 
 function aboutPage() {
-  return `<header><div><p class="overline">ABOUT</p><h1>VocaWin <em>alpha.</em></h1></div></header>
+  return `<header><div><p class="overline">ABOUT</p><h1>VocaWin <em>beta.</em></h1></div></header>
     <section class="about-hero">
       <img class="about-logo" src="${familyLogo}" width="96" height="96" alt="Voca" />
       <h2>VocaWin</h2>
@@ -724,7 +724,7 @@ function aboutPage() {
     <section class="settings-card">
       <p class="settings-group">This build</p>
       <div class="about-copy">
-        <p>This is an unsigned developer alpha. It is not a store listing and not a stable public release. Windows will likely say the publisher is unknown. That is SmartScreen. Use More info, then Run anyway, only if you trust the GitHub Release you downloaded.</p>
+        <p>This is an unsigned beta. It is not a store listing and not a stable public release. Windows will likely say the publisher is unknown. That is SmartScreen. Use More info, then Run anyway, only if you trust the GitHub Release you downloaded.</p>
         <p>The community is expected to help improve it. If something breaks, file an issue.</p>
       </div>
     </section>
@@ -816,7 +816,7 @@ function render() {
     about: aboutPage,
   };
   app.innerHTML = `<aside>
-    <div class="brand"><span class="mark">${sidebarMark}</span><span>VocaWin</span><span class="brand-tag" title="Developer-only build">Alpha</span></div>
+    <div class="brand"><span class="mark">${sidebarMark}</span><span>VocaWin</span><span class="brand-tag" title="Unsigned tester build">Beta</span></div>
     <p class="brand-subtitle">Voice dictation, kept private.</p>
     <nav>${nav("dictation", "Dictation", "◉")}${nav("models", "Models", "◇")}${nav("history", "History", "≡")}${nav("settings", "Settings", "⚙")}${nav("debug", "Debug", "⌗")}${nav("about", "About", "ⓘ")}</nav>
     ${sidebarFooter()}

--- a/web/README.md
+++ b/web/README.md
@@ -1,6 +1,6 @@
 # vocawin.com
 
-Static landing page for VocaWin. No build step, no trackers, system fonts. The page points testers at the unsigned developer alpha on GitHub Releases, with a quieter link to the moving `nightly` tag.
+Static landing page for VocaWin. No build step, no trackers, system fonts. The page points testers at the unsigned beta on GitHub Releases, with a quieter link to the moving `nightly` tag.
 
 ```bash
 python3 -m http.server 4173 --directory .

--- a/web/index.html
+++ b/web/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="VocaWin is Windows voice typing that runs speech-to-text on this PC. Testers can grab an unsigned developer alpha from GitHub Releases. It is part of the Voca family at vocahq.com."
+      content="VocaWin is Windows voice typing that runs speech-to-text on this PC. Testers can grab an unsigned beta from GitHub Releases. It is part of the Voca family at vocahq.com."
     />
     <meta name="theme-color" content="#f4f1e8" />
     <meta name="robots" content="index, follow" />
@@ -14,7 +14,7 @@
     <meta property="og:title" content="VocaWin: voice typing that stays on this PC" />
     <meta
       property="og:description"
-      content="A Windows project in the Voca family. Hold a hotkey, speak, and text is meant to land at your cursor. Speech-to-text runs on this PC after a one-time model download. Unsigned developer alpha for testers, not a store release."
+      content="A Windows project in the Voca family. Hold a hotkey, speak, and text is meant to land at your cursor. Speech-to-text runs on this PC after a one-time model download. Unsigned beta for testers, not a store release."
     />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />
@@ -27,18 +27,18 @@
     <meta property="og:image:height" content="630" />
     <meta
       property="og:image:alt"
-      content="VocaWin: Windows voice typing that stays on this PC. Developer alpha. Unsigned. Part of VocaHQ."
+      content="VocaWin: Windows voice typing that stays on this PC. Beta. Unsigned. Part of VocaHQ."
     />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="VocaWin: voice typing that stays on this PC" />
     <meta
       name="twitter:description"
-      content="Windows voice typing for the Voca family. Speech-to-text runs on this PC after a one-time model download. Unsigned developer alpha for testers."
+      content="Windows voice typing for the Voca family. Speech-to-text runs on this PC after a one-time model download. Unsigned beta for testers."
     />
     <meta name="twitter:image" content="https://vocawin.com/assets/og-image.png" />
     <meta
       name="twitter:image:alt"
-      content="VocaWin: Windows voice typing that stays on this PC. Developer alpha. Unsigned. Part of VocaHQ."
+      content="VocaWin: Windows voice typing that stays on this PC. Beta. Unsigned. Part of VocaHQ."
     />
     <title>VocaWin: voice typing that stays on this PC</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
@@ -65,7 +65,7 @@
           "availability": "https://schema.org/LimitedAvailability",
           "url": "https://github.com/VocaHQ/vocawin/releases"
         },
-        "description": "Unsigned developer alpha of Windows voice typing. Speech-to-text runs on this PC after a one-time model download. Not a Microsoft Store listing or signed public release.",
+        "description": "Unsigned beta of Windows voice typing. Speech-to-text runs on this PC after a one-time model download. Not a Microsoft Store listing or signed public release.",
         "isPartOf": {
           "@type": "Organization",
           "name": "VocaHQ",
@@ -100,17 +100,17 @@
         <a href="#privacy">privacy</a>
         <a href="#family">family</a>
         <a href="#questions">questions</a>
-        <a class="nav-cta" href="https://github.com/VocaHQ/vocawin/releases">download the alpha</a>
+        <a class="nav-cta" href="https://github.com/VocaHQ/vocawin/releases">download the beta</a>
       </nav>
 
       <div class="system-strip" aria-hidden="true">
         <span class="signal">▣</span>
-        <span>developer alpha · unsigned</span>
+        <span>beta · unsigned</span>
         <span data-local-time>10:09</span>
       </div>
 
       <a class="header-cta" href="https://github.com/VocaHQ/vocawin/releases">
-        download the alpha
+        download the beta
         <span aria-hidden="true">↗</span>
       </a>
     </header>
@@ -144,7 +144,7 @@
 
           <div class="floating-card status-note">
             <span>release status</span>
-            <b>developer alpha</b>
+            <b>beta</b>
             <b>unsigned</b>
             <b>source public</b>
           </div>
@@ -186,7 +186,7 @@
                   d="M12 3.75a.75.75 0 0 1 .75.75v9.19l2.72-2.72a.75.75 0 1 1 1.06 1.06l-4 4a.75.75 0 0 1-1.06 0l-4-4a.75.75 0 0 1 1.06-1.06l2.72 2.72V4.5A.75.75 0 0 1 12 3.75ZM4.5 16.5A.75.75 0 0 1 5.25 15.75h13.5a.75.75 0 0 1 0 1.5H5.25A.75.75 0 0 1 4.5 16.5Z"
                 />
               </svg>
-              download the alpha
+              download the beta
             </a>
           </div>
           <p class="hero-quiet">
@@ -197,7 +197,7 @@
             <a href="https://github.com/VocaHQ/vocawin/releases/tag/nightly">nightly from main</a>
           </p>
           <p class="hero-note">
-            Developer alpha. Unsigned. Windows will likely say the publisher is
+            Beta. Unsigned. Windows will likely say the publisher is
             unknown. More info, then Run anyway. Latest tagged build is on
             <a href="https://github.com/VocaHQ/vocawin/releases">Releases</a>.
           </p>
@@ -369,7 +369,7 @@
                 <span>Linux · available</span>
                 <span>macOS · beta</span>
                 <span>phone · beta / source</span>
-                <span class="current">Windows · developer alpha</span>
+                <span class="current">Windows · beta</span>
                 <span>gateway · early</span>
               </div>
             </div>
@@ -382,7 +382,7 @@
           <span class="section-tag">how it works</span>
           <h2 id="how-title">the path<br />on this PC.</h2>
           <p>
-            This is the flow in the unsigned alpha. Download a model once, hold
+            This is the flow in the unsigned beta. Download a model once, hold
             the hotkey, and text is meant to land at the caret. It is still
             tester-only, not a store listing.
           </p>
@@ -438,7 +438,7 @@
             <p>
               The transcript is meant to appear in the focused field. Elevated
               admin windows may refuse SendInput. That limitation is real in
-              this alpha.
+              this beta.
             </p>
           </article>
         </div>
@@ -470,7 +470,7 @@
               <span class="section-tag">privacy is a route</span>
               <h2 id="privacy-title">on this Windows PC.<br />not a Voca cloud.</h2>
               <p>
-                The alpha records with WASAPI on this machine and runs a local
+                The beta records with WASAPI on this machine and runs a local
                 speech-to-text model. That is on-device. It is not self-hosted
                 gateway mode, and it is not a hosted speech API.
               </p>
@@ -517,7 +517,7 @@
       <section class="status-section" id="status" aria-labelledby="status-title">
         <div class="section-heading reveal">
           <span class="section-tag">availability</span>
-          <h2 id="status-title">an unsigned alpha,<br />not a store listing.</h2>
+          <h2 id="status-title">an unsigned beta,<br />not a store listing.</h2>
           <p>
             You can install a tester build from GitHub Releases. Treat it as
             early. It is not signed, not on the Microsoft Store, and not a
@@ -527,9 +527,9 @@
         <div class="status-grid">
           <article class="status-card reveal">
             <p class="tiny-label">today</p>
-            <h3>Download the alpha</h3>
+            <h3>Download the beta</h3>
             <ul class="install-facts">
-              <li><b>Status</b><span>Developer alpha. Unsigned.</span></li>
+              <li><b>Status</b><span>Beta. Unsigned.</span></li>
               <li><b>Files</b><span>NSIS current-user setup.exe and MSI</span></li>
               <li><b>Needs</b><span>Windows 10 version 1809+ or Windows 11</span></li>
               <li><b>License</b><span>AGPL-3.0-or-later</span></li>
@@ -672,12 +672,12 @@
               <p>
                 VocaWin is a native Windows app built in the open: tray icon,
                 hotkey, local Whisper model, text at the caret. No Voca
-                account. No hosted speech service. The unsigned alpha lives on
+                account. No hosted speech service. The unsigned beta lives on
                 GitHub Releases. This is still a tester build, not a signed
                 store ship.
               </p>
               <a class="text-link" href="https://github.com/VocaHQ/vocawin/releases">
-                download the alpha from Releases <span>↗</span>
+                download the beta from Releases <span>↗</span>
               </a>
             </div>
             <div class="manifesto-aside" aria-hidden="true">
@@ -701,7 +701,7 @@
           <details open>
             <summary>Can I install VocaWin today?<span aria-hidden="true">＋</span></summary>
             <p>
-              Yes. An unsigned developer alpha is on
+              Yes. An unsigned beta is on
               <a href="https://github.com/VocaHQ/vocawin/releases">GitHub Releases</a>.
               Windows will likely warn that the publisher is unknown. That is
               SmartScreen doing its job. More info, then Run anyway if you
@@ -719,9 +719,9 @@
               Yes. A moving unsigned build from
               <code>main</code> is on the
               <a href="https://github.com/VocaHQ/vocawin/releases/tag/nightly">nightly</a>
-              GitHub Release. Same SmartScreen story as the alpha. Prefer the
-              tagged alpha if you want the last cut we named. Nightly is for
-              testers who want today's tree.
+              GitHub Release. Same SmartScreen story as the tagged builds.
+              Prefer the latest tagged Release if you want the last cut we
+              named. Nightly is for testers who want today's tree.
             </p>
           </details>
           <details>
@@ -730,7 +730,7 @@
               That is the design. After a Whisper model is downloaded, recording
               and speech-to-text run on this Windows machine. No Voca cloud, no
               Voca account, no hosted speech API. The first model download does
-              need a network. Treat the alpha as early.
+              need a network. Treat the beta as early.
             </p>
           </details>
           <details>
@@ -754,7 +754,7 @@
           <details>
             <summary>What hotkey will it use?<span aria-hidden="true">＋</span></summary>
             <p>
-              The alpha defaults to Right Alt for push-to-talk, with an
+              The beta defaults to Right Alt for push-to-talk, with an
               optional double-tap toggle. You can change the hotkey in Settings.
               That default can still move.
             </p>
@@ -782,16 +782,16 @@
       <section class="close-section dot-field" id="follow" aria-labelledby="follow-title">
         <div class="close-copy reveal">
           <img src="assets/brand/voca-logo.svg" alt="" width="88" height="88" />
-          <p class="eyebrow">unsigned developer alpha</p>
+          <p class="eyebrow">unsigned beta</p>
           <h2 id="follow-title">try Windows if you<br />want the rough cut.</h2>
           <p>
-            Grab the alpha from GitHub Releases if you want to poke at this PC.
+            Grab the beta from GitHub Releases if you want to poke at this PC.
             If you need a quieter desk, start at vocahq.com and pick a machine
             that already ships.
           </p>
           <div class="hero-actions">
             <a class="button button-primary" href="https://github.com/VocaHQ/vocawin/releases">
-              download the alpha <span>↗</span>
+              download the beta <span>↗</span>
             </a>
             <a class="button button-secondary" href="https://github.com/VocaHQ/vocawin/issues">
               file an issue <span>↗</span>
@@ -837,7 +837,7 @@
       </nav>
       <div class="footer-bottom">
         <span>© <span data-current-year>2026</span> VocaHQ</span>
-        <span>developer alpha on Windows. the rest of the family lives at vocahq.com.</span>
+        <span>beta on Windows. the rest of the family lives at vocahq.com.</span>
       </div>
     </footer>
   </body>

--- a/web/site.webmanifest
+++ b/web/site.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "VocaWin",
   "short_name": "VocaWin",
-  "description": "Windows voice typing that stays on this PC. Unsigned developer alpha.",
+  "description": "Windows voice typing that stays on this PC. Unsigned beta.",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#f4f1e8",

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -30,7 +30,7 @@ test("document ids are unique", () => {
   assert.equal(new Set(ids).size, ids.length);
 });
 
-test("unsigned alpha download is explicit and not oversold", () => {
+test("unsigned beta download is explicit and not oversold", () => {
   assert.match(
     html,
     /class="hero-copy"[\s\S]*class="button button-primary" href="https:\/\/github\.com\/VocaHQ\/vocawin\/releases"/,
@@ -42,15 +42,18 @@ test("unsigned alpha download is explicit and not oversold", () => {
   );
   assert.doesNotMatch(html, /\/releases\/tag\/v/);
   assert.doesNotMatch(html, /softwareVersion/);
+  assert.doesNotMatch(html, /v0\.1\.0-beta\.1/);
+  assert.doesNotMatch(html, /v0\.1\.0-alpha/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocawin\/issues"/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocawin\/blob\/main\/docs\/setup\.md"/);
   assert.match(html, /unsigned/i);
   assert.match(html, /SmartScreen|publisher is unknown/i);
   assert.match(html, /More info, then Run anyway/i);
-  assert.match(html, /developer alpha/i);
-  assert.match(html, /Windows · developer alpha/);
+  assert.match(html, /\bbeta\b/i);
+  assert.match(html, /Windows · beta/);
+  assert.doesNotMatch(html, /developer alpha/i);
   assert.doesNotMatch(html, /href="\/setup"/);
-  assert.match(html, /download the alpha/i);
+  assert.match(html, /download the beta/i);
   assert.match(html, /NSIS current-user setup\.exe and (an )?MSI/i);
   assert.match(html, /LimitedAvailability/);
   assert.doesNotMatch(html, /PreOrder/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Jatin has been daily-driving this and wants the public word to match VocaMac: Beta. Still unsigned. SmartScreen and unknown publisher stay expected. Still not a Store listing and not a stable public ship. Nightly from main stays.

This PR flips visitor-facing and in-app chrome from developer alpha to Beta. App version files stay 0.1.0. The latest tagged Release is still v0.1.0-alpha.3. Do not treat v0.1.0-beta.1 as live. After Jatin says to cut it, the next named tester tag is v0.1.0-beta.1. windows-alpha-release.yml still fires on v* tags.

Installer welcome text no longer says vocawin.com is Coming soon. The site is live and points testers at GitHub Releases.

The GitHub repo description still says Developer alpha. This token could not edit it. Jatin can run `gh repo edit VocaHQ/vocawin --description` when he wants that flipped too.

Do not merge until Jatin wants it. Do not push the tag from this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc17ffe0-4d3e-4a89-b4df-00e23c0cce4d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc17ffe0-4d3e-4a89-b4df-00e23c0cce4d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

