### PR TITLE
fix: match family cards to PRODUCT.md and keep headings visible

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -292,7 +292,7 @@
               </div>
               <div class="note-page">
                 <span class="note-date">LOCAL · UNSAVED</span>
-                <h4>Standup notes</h4>
+                <p class="note-title">Standup notes</p>
                 <p>
                   Ship the notes after lunch and move the review to
                   <mark>Thursday.</mark><span class="text-caret"></span>
@@ -368,7 +368,7 @@
               <div class="family-mini-list">
                 <span>Linux · available</span>
                 <span>macOS · beta</span>
-                <span>phone · beta / source</span>
+                <span>phone · beta / testflight</span>
                 <span class="current">Windows · beta</span>
                 <span>gateway · early</span>
               </div>
@@ -622,12 +622,13 @@
             <div class="eco-head">
               <img src="assets/icons/android.svg" alt="" width="20" height="20" />
               <span>iPhone + Android</span>
-              <small>beta / source build</small>
+              <small>beta / testflight</small>
             </div>
             <h3>VocaPhone</h3>
             <p>
-              A private voice keyboard. Android has public beta releases.
-              iPhone currently needs an iOS 17+ source build.
+              A private voice keyboard for phones. Android 13+ has a public
+              beta. iPhone is a public TestFlight beta for iOS 17+, capped at
+              1,000 seats, or build from source.
             </p>
             <div class="eco-links">
               <a href="https://vocaphone.vocahq.com/">vocaphone.vocahq.com <span aria-hidden="true">↗</span></a>
@@ -647,9 +648,8 @@
               code. Use a trusted LAN, a private encrypted network, or HTTPS.
             </p>
             <div class="eco-links">
-              <a href="https://github.com/VocaHQ/vocagateway">
-                github.com/VocaHQ/vocagateway <span aria-hidden="true">↗</span>
-              </a>
+              <a href="https://vocagateway.vocahq.com/">vocagateway.vocahq.com <span aria-hidden="true">↗</span></a>
+              <a href="https://github.com/VocaHQ/vocagateway">source</a>
             </div>
           </article>
         </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -24,6 +24,7 @@
   --font-mono: "Cascadia Mono", "SFMono-Regular", Consolas, "Liberation Mono",
     monospace;
   --measure: 1180px;
+  --sticky-offset: 7.5rem;
 }
 
 * {
@@ -33,18 +34,25 @@
 html {
   overflow-x: clip;
   scroll-behavior: smooth;
-  scroll-padding-top: 76px;
+  scroll-padding-top: var(--sticky-offset);
 }
 
 body {
   margin: 0;
   overflow-x: clip;
+  scroll-padding-top: var(--sticky-offset);
   color: var(--ink);
   background: var(--paper);
   font-family: var(--font-body);
   font-size: 16px;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
+}
+
+h2,
+h3,
+[id] {
+  scroll-margin-top: var(--sticky-offset);
 }
 
 ::selection {
@@ -1018,7 +1026,7 @@ code {
   letter-spacing: 0.08em;
 }
 
-.note-page h4 {
+.note-page .note-title {
   margin: 10px 0 12px;
   font-family: var(--font-display);
   font-size: 28px;
@@ -1785,6 +1793,10 @@ code {
 }
 
 @media (max-width: 920px) {
+  :root {
+    --sticky-offset: 6.75rem;
+  }
+
   .menu-bar {
     grid-template-columns: 1fr auto;
   }

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -89,11 +89,48 @@ test("vocahq.com and the family are linked", () => {
   assert.match(html, /href="https:\/\/vocalinux\.com\/"/);
   assert.match(html, /href="https:\/\/vocamac\.com\/"/);
   assert.match(html, /href="https:\/\/vocaphone\.vocahq\.com\/"/);
+  assert.match(html, /href="https:\/\/vocagateway\.vocahq\.com\/"/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocagateway"/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocawin"/);
   assert.match(html, /href="https:\/\/discord\.gg\/t6muquAJbm"/);
   assert.match(html, /href="https:\/\/x\.com\/vocahq"/);
   assert.doesNotMatch(html, /jatinkrmalik\/vocawin/);
+});
+
+test("family cards match PRODUCT.md phone and gateway status", () => {
+  assert.match(html, /href="https:\/\/vocagateway\.vocahq\.com\/"/);
+  assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocagateway"/);
+  assert.match(html, /href="https:\/\/vocaphone\.vocahq\.com\/"/);
+  assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocaphone"/);
+  assert.match(html, /TestFlight/);
+  assert.match(html, /1,000\s+seats/);
+  assert.match(html, /Android 13\+/);
+  assert.match(html, /iOS 17\+/);
+  assert.match(html, /phone · beta \/ testflight/);
+  assert.match(html, /<small>beta \/ testflight<\/small>/);
+  assert.doesNotMatch(html, /iPhone currently needs an iOS 17\+ source build/);
+  assert.doesNotMatch(html, /beta \/ source build/);
+  assert.doesNotMatch(html, /phone · beta \/ source</);
+  const gatewayCard = html.slice(html.indexOf("<h3>VocaGateway</h3>"));
+  assert.ok(
+    gatewayCard.indexOf("vocagateway.vocahq.com") <
+      gatewayCard.indexOf("github.com/VocaHQ/vocagateway"),
+    "VocaGateway site link should come before source",
+  );
+});
+
+test("decorative mockups stay out of the heading outline", () => {
+  assert.match(html, /Standup notes/);
+  assert.doesNotMatch(html, /<h[1-6][^>]*>\s*Standup notes\s*<\/h[1-6]>/);
+  assert.doesNotMatch(html, /<h4\b/);
+});
+
+test("sticky header leaves room for in-page headings", () => {
+  assert.match(css, /--sticky-offset:\s*7\.5rem/);
+  assert.match(css, /scroll-padding-top:\s*var\(--sticky-offset\)/);
+  assert.match(css, /h2,\s*\n\s*h3,\s*\n\s*\[id\]\s*\{/);
+  assert.match(css, /scroll-margin-top:\s*var\(--sticky-offset\)/);
+  assert.doesNotMatch(css, /scroll-padding-top:\s*76px/);
 });
 
 test("Windows chrome is used instead of macOS traffic lights", () => {


### PR DESCRIPTION
Fixes #33.

Family cards on vocawin.com still called iPhone a source-only build. PRODUCT.md (verified 2026-08-24) has an Android 13+ public beta and an iOS 17+ public TestFlight beta capped at 1,000 seats, or source. The VocaPhone card and the family mini-map now say that. The VocaGateway card now leads with vocagateway.vocahq.com, then the GitHub source, same as Linux and Mac.

The sticky header was covering H2 and H3 targets on scroll. Headings and in-page ids now have enough scroll margin on desktop and the mobile bar. Standup notes in the fake editor is a paragraph, not a heading.

Site tests require the gateway site, reject the old source-only iPhone copy, and keep the honesty checks. Ran node --test tests/site.test.mjs from web/.

## Test plan

From web/, run node --test tests/site.test.mjs. On the page, confirm the VocaPhone card mentions TestFlight and 1,000 seats, the mini-map is not source-only, and VocaGateway lists the site before source. Jump to #family and to the story heading "Windows is one desk in a larger room." on a phone-width viewport; both should sit below the sticky bar. Confirm Standup notes is not a heading.