### PR TITLE
Use the canonical Discord invite

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2348,7 +2348,7 @@ fn allowed_external_url(url: &str) -> bool {
         "https://vocamac.com",
         "https://vocaphone.vocahq.com",
         "https://vocagateway.vocahq.com",
-        "https://discord.gg/UMJduhcqn",
+        "https://discord.gg/t6muquAJbm",
         "https://x.com/vocahq",
         "https://github.com/VocaHQ/vocawin",
         "https://github.com/VocaHQ/vocawin/issues/new/choose",

--- a/src/main.ts
+++ b/src/main.ts
@@ -755,7 +755,7 @@ function aboutPage() {
         <p>Bugs, feedback, and feature ideas open a new GitHub issue. You pick the template on the next screen.</p>
         <ul class="about-talk" role="list">
           <li><button type="button" class="primary about-report" data-open="https://github.com/VocaHQ/vocawin/issues/new/choose">${githubMark}<span>Report a bug or idea</span></button></li>
-          <li><button type="button" class="about-talk-btn" data-open="https://discord.gg/UMJduhcqn">${discordMark}<span>Discord</span></button></li>
+          <li><button type="button" class="about-talk-btn" data-open="https://discord.gg/t6muquAJbm">${discordMark}<span>Discord</span></button></li>
           <li><button type="button" class="about-talk-btn" data-open="https://x.com/vocahq">${xMark}<span>X</span></button></li>
           <li><button type="button" class="about-talk-btn" data-open="mailto:hello@vocahq.com">${mailMark}<span>Email</span></button></li>
         </ul>


### PR DESCRIPTION
About and the open-external allow list still pointed at discord.gg/UMJduhcqn. The rest of the repo already uses t6muquAJbm, which does not expire.