### PR TITLE
Name the Win beta and call Gateway Beta

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@ This is the checklist we already use. A `v*` tag is what ships a **named** teste
 
 ## Tag
 
-The next named tester tag is `v0.1.0-beta.1`. Cut it only after Jatin asks. The latest tagged Release today is still `v0.1.0-alpha.3`. Do not treat `v0.1.0-beta.1` as live until that tag is pushed. Tag the commit you want testers to run, then push it. That is the only trigger.
+The latest tagged tester cut is `v0.1.0-beta.1`. It is live on GitHub Releases. Cut the next `v*` tag only after Jatin asks. Tag the commit testers should run, then push it. That is the only trigger.
 
 `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` stay at `0.1.0` across these cuts. The installers keep the `VocaWin_0.1.0_*` filenames. The Git tag is the public version. Do not bump the app version for a beta.
 
@@ -34,7 +34,7 @@ You can rename the Release to drop the `v` and the `(Windows beta)` suffix. That
 
 ## Public pages
 
-[vocawin.com](https://vocawin.com) lives in `web/` and publishes from `main` when `web/` changes. The hero download still goes to [Releases](https://github.com/VocaHQ/vocawin/releases), not a `v*` tag. A quieter [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly) link is allowed because that tag is moving, not a version pin. Do not pin `v0.1.0-beta.1` or any other `v*` tag in the hero, the FAQ, or JSON-LD. Check the live page still says beta, unsigned, More info then Run anyway.
+[vocawin.com](https://vocawin.com) lives in `web/` and publishes from `main` when `web/` changes. Name the current tagged cut (`v0.1.0-beta.1`) next to the download facts and in JSON-LD `softwareVersion`, and link [that tag](https://github.com/VocaHQ/vocawin/releases/tag/v0.1.0-beta.1). The primary download button can still go to [Releases](https://github.com/VocaHQ/vocawin/releases). Nightly stays on the moving [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly) tag. When we cut the next named tag, bump those pins in the same site PR. Check the live page still says beta, unsigned, More info then Run anyway.
 
 The README badge is `github/v/release` with `include_prereleases`. It tracks the latest prerelease by itself. Leave it pointed at `/releases`. Do not pin a tag in the README.
 
@@ -50,4 +50,4 @@ VocaHQ owns vocahq.com and the family PRODUCT.md. If that page still lists an ol
 
 ## What not to do
 
-Do not pin a `v*` tag in the README or on vocawin.com. Do not bump the `0.1.0` app version for a beta or a nightly. Do not tell testers the build is signed, Coming soon, or Available now. Do not cut a named beta from a branch click. Nightly may be dispatched by hand.
+Do not pin a `v*` tag in the README. vocawin.com should name the current tagged cut and get updated on the next tag. Do not bump the `0.1.0` app version for a beta or a nightly. Do not tell testers the build is signed, Coming soon, or Available now. Do not cut a named beta from a branch click. Nightly may be dispatched by hand.

--- a/web/index.html
+++ b/web/index.html
@@ -56,7 +56,8 @@
         "applicationCategory": "UtilitiesApplication",
         "operatingSystem": "Windows 10, Windows 11",
         "url": "https://vocawin.com/",
-        "downloadUrl": "https://github.com/VocaHQ/vocawin/releases",
+        "downloadUrl": "https://github.com/VocaHQ/vocawin/releases/tag/v0.1.0-beta.1",
+        "softwareVersion": "v0.1.0-beta.1",
         "isAccessibleForFree": true,
         "offers": {
           "@type": "Offer",
@@ -198,8 +199,8 @@
           </p>
           <p class="hero-note">
             Beta. Unsigned. Windows will likely say the publisher is
-            unknown. More info, then Run anyway. Latest tagged build is on
-            <a href="https://github.com/VocaHQ/vocawin/releases">Releases</a>.
+            unknown. More info, then Run anyway. Latest tagged build is
+            <a href="https://github.com/VocaHQ/vocawin/releases/tag/v0.1.0-beta.1">v0.1.0-beta.1</a>.
           </p>
           <ul class="hero-proof">
             <li>
@@ -370,7 +371,7 @@
                 <span>macOS · beta</span>
                 <span>phone · beta / testflight</span>
                 <span class="current">Windows · beta</span>
-                <span>gateway · early</span>
+                <span>gateway · beta</span>
               </div>
             </div>
           </div>
@@ -519,9 +520,9 @@
           <span class="section-tag">availability</span>
           <h2 id="status-title">an unsigned beta,<br />not a store listing.</h2>
           <p>
-            You can install a tester build from GitHub Releases. Treat it as
-            early. It is not signed, not on the Microsoft Store, and not a
-            stable public release.
+            You can install a tester build from GitHub Releases. It is
+            unsigned, not on the Microsoft Store, and not a stable public
+            release.
           </p>
         </div>
         <div class="status-grid">
@@ -530,6 +531,7 @@
             <h3>Download the beta</h3>
             <ul class="install-facts">
               <li><b>Status</b><span>Beta. Unsigned.</span></li>
+              <li><b>Tagged</b><span><a href="https://github.com/VocaHQ/vocawin/releases/tag/v0.1.0-beta.1">v0.1.0-beta.1</a></span></li>
               <li><b>Files</b><span>NSIS current-user setup.exe and MSI</span></li>
               <li><b>Needs</b><span>Windows 10 version 1809+ or Windows 11</span></li>
               <li><b>License</b><span>AGPL-3.0-or-later</span></li>
@@ -640,7 +642,7 @@
             <div class="eco-head">
               <img src="assets/icons/server.svg" alt="" width="20" height="20" />
               <span>infrastructure</span>
-              <small>early</small>
+              <small>beta</small>
             </div>
             <h3>VocaGateway</h3>
             <p>
@@ -730,7 +732,7 @@
               That is the design. After a Whisper model is downloaded, recording
               and speech-to-text run on this Windows machine. No Voca cloud, no
               Voca account, no hosted speech API. The first model download does
-              need a network. Treat the beta as early.
+              need a network. The build is unsigned and tester-only.
             </p>
           </details>
           <details>

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -40,9 +40,12 @@ test("unsigned beta download is explicit and not oversold", () => {
     html,
     /href="https:\/\/github\.com\/VocaHQ\/vocawin\/releases\/tag\/nightly"/,
   );
-  assert.doesNotMatch(html, /\/releases\/tag\/v/);
-  assert.doesNotMatch(html, /softwareVersion/);
-  assert.doesNotMatch(html, /v0\.1\.0-beta\.1/);
+  assert.match(
+    html,
+    /href="https:\/\/github\.com\/VocaHQ\/vocawin\/releases\/tag\/v0\.1\.0-beta\.1"/,
+  );
+  assert.match(html, /"softwareVersion": "v0\.1\.0-beta\.1"/);
+  assert.match(html, /v0\.1\.0-beta\.1/);
   assert.doesNotMatch(html, /v0\.1\.0-alpha/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocawin\/issues"/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocawin\/blob\/main\/docs\/setup\.md"/);
@@ -51,6 +54,10 @@ test("unsigned beta download is explicit and not oversold", () => {
   assert.match(html, /More info, then Run anyway/i);
   assert.match(html, /\bbeta\b/i);
   assert.match(html, /Windows · beta/);
+  assert.match(html, /gateway · beta/);
+  assert.doesNotMatch(html, /gateway · early/);
+  assert.doesNotMatch(html, /Treat it as\s+early/i);
+  assert.doesNotMatch(html, /Treat the beta as early/i);
   assert.doesNotMatch(html, /developer alpha/i);
   assert.doesNotMatch(html, /href="\/setup"/);
   assert.match(html, /download the beta/i);
@@ -108,6 +115,8 @@ test("family cards match PRODUCT.md phone and gateway status", () => {
   assert.match(html, /iOS 17\+/);
   assert.match(html, /phone · beta \/ testflight/);
   assert.match(html, /<small>beta \/ testflight<\/small>/);
+  assert.match(html, /<small>beta<\/small>/);
+  assert.doesNotMatch(html, /<small>early<\/small>/);
   assert.doesNotMatch(html, /iPhone currently needs an iOS 17\+ source build/);
   assert.doesNotMatch(html, /beta \/ source build/);
   assert.doesNotMatch(html, /phone · beta \/ source</);


### PR DESCRIPTION
Gateway still said Early on vocawin.com. PRODUCT.md already has VocaGateway as Beta. The Win download block also hid the tagged cut.

This names v0.1.0-beta.1 next to the download facts, points JSON-LD at that tag, and talks about unsigned tester builds without using Early as a status word. Gateway stays optional self-hosted at vocagateway.vocahq.com.

Does not close #41.