### PR TITLE
Settings Gateway: opt-in local Compose pair helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Instructions for coding agents on **VocaWin** (`VocaHQ/vocawin`). Default branch is `main`. License: AGPL-3.0-or-later.
 
-Native Windows voice typing: hold a hotkey, speak, text at the caret. After a Whisper or ONNX model is on disk, capture and transcription stay on this PC. No Voca account, no hosted speech API, no product telemetry, no gateway mode.
+Native Windows voice typing: hold a hotkey, speak, text at the caret. After a Whisper or ONNX model is on disk, capture and transcription stay on this PC. No Voca account, no hosted speech API, no product telemetry. Optional Settings → Gateway can start a local VocaGateway container for pairing other clients; that path is not on-device and is not used for VocaWin dictation.
 
 This is a **beta**. Installers are **unsigned**. Do not call it signed, Store-ready, stable, or a public ship.
 
@@ -146,7 +146,8 @@ If you change landing copy, run `node --test tests/site.test.mjs` from `web/`. D
 ## Do not
 
 - Claim Store, signed, stable, auto-update, or “100% offline” (the first model download uses the network).
-- Add Voca cloud, gateway mode, telemetry, or `latest.json`.
+- Add Voca cloud, telemetry, or `latest.json`.
+- Route VocaWin dictation through Gateway (Settings → Gateway is pair-helper only).
 - Offer a catalog Download that cannot transcribe.
 - Change installer copy in `src-tauri/windows/nsis-hooks.nsh` without matching README honesty.
 - Leave the primary checkout on a feature branch or dirty.

--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ Same privacy bar, different machines. Start at [vocahq.com](https://vocahq.com) 
 | macOS | **VocaMac** | [vocamac.com](https://vocamac.com) | [VocaHQ/vocamac](https://github.com/VocaHQ/vocamac) | Beta |
 | iPhone / Android | **VocaPhone** | [vocaphone.vocahq.com](https://vocaphone.vocahq.com) | [VocaHQ/vocaphone](https://github.com/VocaHQ/vocaphone) | Android beta / iOS TestFlight |
 | Windows | **VocaWin** | [vocawin.com](https://vocawin.com) | [VocaHQ/vocawin](https://github.com/VocaHQ/vocawin) | Beta |
-| Infrastructure | **VocaGateway** | [vocagateway.vocahq.com](https://vocagateway.vocahq.com) | [VocaHQ/vocagateway](https://github.com/VocaHQ/vocagateway) | Early |
+| Infrastructure | **VocaGateway** | [vocagateway.vocahq.com](https://vocagateway.vocahq.com) | [VocaHQ/vocagateway](https://github.com/VocaHQ/vocagateway) | Beta |
 
-VocaGateway is optional self-hosted compute for other Voca clients. VocaWin does not expose a gateway mode today.
+VocaGateway is optional self-hosted compute. VocaWin can start a local Gateway container from Settings for pairing phones and other clients. Win dictation itself stays on this PC. Gateway is not on-device: audio that uses it leaves this machine for the container.
 
 ## Tech Stack
 

--- a/docs/gateway-embed.md
+++ b/docs/gateway-embed.md
@@ -1,0 +1,51 @@
+# Gateway embed (VocaWin Settings)
+
+Opt-in Settings group that can start a **local** VocaGateway Compose project on Windows (Docker Desktop + WSL2). This is a pair helper for phones and other Voca clients. VocaWin dictation does **not** route through Gateway.
+
+Contract source: VocaHQ frozen embed notes (`FROZEN.md`). Pin and paths below must stay aligned with that contract.
+
+## Pin (one place)
+
+| Constant | Value |
+| --- | --- |
+| Release tag | `v0.1.0` |
+| Image | `ghcr.io/vocahq/vocagateway:v0.1.0` |
+| Rust constants | `GATEWAY_RELEASE_TAG` / `GATEWAY_IMAGE` in `src-tauri/src/gateway.rs` |
+| Compose file | `src-tauri/gateway/compose.yaml` (written into app data on Start) |
+
+Do not use floating `latest`.
+
+If GHCR has no public image for that tag yet, fall back to a shallow clone of `VocaHQ/vocagateway` at tag `v0.1.0` into the gateway data dir and `docker compose … up -d --build`. Prefer image pull when the registry publish exists.
+
+## Compose
+
+- Project name: `vocagateway` (`docker compose -p vocagateway`)
+- File: `%APPDATA%\com.vocahq.vocawin\gateway\compose.yaml`
+- Env: `%APPDATA%\com.vocahq.vocawin\gateway\.env` (token mode restricted on Unix; never commit)
+- Service: `gateway` only (CPU). No CUDA/Vulkan profiles in MVP.
+- Start: `docker compose -p vocagateway -f <dir>/compose.yaml --env-file <dir>/.env up -d`
+- Stop: `… down` **without** `--volumes`
+
+`.env` keys written by VocaWin:
+
+- `VOCAGATEWAY_TOKEN` (≥32 hex chars)
+- `VOCAGATEWAY_PUBLISH_HOST=0.0.0.0`
+- `VOCAGATEWAY_PUBLISH_PORT=8765`
+- `VOCAGATEWAY_PUBLIC_URL` (mandatory non-loopback under Docker Desktop)
+- `VOCAGATEWAY_IMAGE` (pinned)
+
+## Health and pairing
+
+| Check | Meaning |
+| --- | --- |
+| `GET http://127.0.0.1:8765/health/live` | Process up |
+| `GET …/health/ready` | Ready for dictation (`503` = not yet) |
+| Pairable | live + non-loopback `PUBLIC_URL` + token (pairable **before** Ready) |
+| Pairing | `Authorization: Bearer <token>` `GET /v1/admin/pairing?url=…` |
+| QR | Prefer `GET /v1/admin/pairing/qr.svg` |
+
+Never put `127.0.0.1` / `localhost` in the QR or public URL.
+
+## Honesty
+
+Gateway is **not on-device**. Audio that uses it leaves this PC for the container. Docs: [vocagateway.vocahq.com](https://vocagateway.vocahq.com). Store/MSIX and code signing stay out of scope.

--- a/docs/gateway-embed.md
+++ b/docs/gateway-embed.md
@@ -41,8 +41,8 @@ If GHCR has no public image for that tag yet, fall back to a shallow clone of `V
 | `GET http://127.0.0.1:8765/health/live` | Process up |
 | `GET …/health/ready` | Ready for dictation (`503` = not yet) |
 | Pairable | live + non-loopback `PUBLIC_URL` + token (pairable **before** Ready) |
-| Pairing | `Authorization: Bearer <token>` `GET /v1/admin/pairing?url=…` |
-| QR | Prefer `GET /v1/admin/pairing/qr.svg` |
+| Pairing | `Authorization: Bearer <token>` `GET /v1/admin/pairing?url=…` (Rust only; UI gets URL + QR, not the raw payload/token) |
+| QR | Prefer `GET /v1/admin/pairing/qr.svg` (sanitized before Settings HTML) |
 
 Never put `127.0.0.1` / `localhost` in the QR or public URL.
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5180,6 +5180,7 @@ dependencies = [
  "cpal",
  "flate2",
  "futures-util",
+ "getrandom 0.2.17",
  "hound",
  "reqwest 0.12.28",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1", features = ["fs", "io-util", "rt"] }
 tar = "0.4"
 flate2 = "1"
 thiserror = "2"
+getrandom = "0.2"
 
 # Non-Windows keeps CPU-only whisper for shared unit tests.
 [target.'cfg(not(windows))'.dependencies]

--- a/src-tauri/gateway/compose.yaml
+++ b/src-tauri/gateway/compose.yaml
@@ -1,0 +1,33 @@
+# Desktop-embed Compose for VocaWin Settings → Gateway (opt-in).
+# Pin: GATEWAY_IMAGE in gateway.rs (v0.1.0). Do not float to latest.
+# Project: docker compose -p vocagateway … (name below is a hint only).
+name: vocagateway
+
+services:
+  gateway:
+    image: ghcr.io/vocahq/vocagateway:v0.1.0
+    restart: unless-stopped
+    init: true
+    ports:
+      - "${VOCAGATEWAY_PUBLISH_HOST:-0.0.0.0}:${VOCAGATEWAY_PUBLISH_PORT:-8765}:${VOCAGATEWAY_PORT:-8765}"
+    environment:
+      VOCAGATEWAY_TOKEN_FILE: /run/secrets/vocagateway_token
+      VOCAGATEWAY_DEBUG: ${VOCAGATEWAY_DEBUG:-false}
+      VOCAGATEWAY_PUBLIC_URL: ${VOCAGATEWAY_PUBLIC_URL:-}
+      VOCAGATEWAY_PAIRING_URL: ${VOCAGATEWAY_PAIRING_URL:-}
+      VOCAGATEWAY_BIND_HOST: ${VOCAGATEWAY_BIND_HOST:-0.0.0.0}
+      VOCAGATEWAY_PORT: ${VOCAGATEWAY_PORT:-8765}
+      VOCAGATEWAY_ENGINE: ${VOCAGATEWAY_ENGINE:-auto}
+      VOCAGATEWAY_RETENTION_HOURS: ${VOCAGATEWAY_RETENTION_HOURS:-24}
+      VOCAGATEWAY_DELETE_SUCCESSFUL_AUDIO: ${VOCAGATEWAY_DELETE_SUCCESSFUL_AUDIO:-true}
+    secrets:
+      - vocagateway_token
+    volumes:
+      - vocagateway-data:/data
+
+secrets:
+  vocagateway_token:
+    environment: VOCAGATEWAY_TOKEN
+
+volumes:
+  vocagateway-data:

--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -61,7 +61,6 @@ pub struct GatewayStatus {
 #[serde(rename_all = "camelCase")]
 pub struct GatewayPairing {
     pub url: String,
-    pub payload: String,
     pub qr_svg: Option<String>,
 }
 
@@ -523,7 +522,6 @@ pub async fn pairing(dir: &Path, public_url: &str) -> Result<GatewayPairing, Str
     let qr_svg = fetch_qr_svg(&client, &token, &url).await;
     Ok(GatewayPairing {
         url: parsed.url.unwrap_or(url),
-        payload: parsed.payload,
         qr_svg,
     })
 }

--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -1,0 +1,699 @@
+//! Opt-in local VocaGateway via Docker Desktop Compose.
+//! Pair helper for phones and other clients. Not used for VocaWin dictation.
+
+use serde::{Deserialize, Serialize};
+use std::{
+    fs,
+    net::UdpSocket,
+    path::{Path, PathBuf},
+    process::Command,
+    time::Duration,
+};
+
+/// Single pin for the desktop-embed image and docs. Not `latest`.
+pub const GATEWAY_RELEASE_TAG: &str = "v0.1.0";
+pub const GATEWAY_IMAGE: &str = "ghcr.io/vocahq/vocagateway:v0.1.0";
+pub const COMPOSE_PROJECT: &str = "vocagateway";
+pub const COMPOSE_SERVICE: &str = "gateway";
+pub const PUBLISH_HOST: &str = "0.0.0.0";
+pub const PUBLISH_PORT: u16 = 8765;
+pub const LOCAL_BASE_URL: &str = "http://127.0.0.1:8765";
+pub const WEBUI_URL: &str = "http://127.0.0.1:8765/";
+pub const DOCKER_DESKTOP_INSTALL_URL: &str =
+    "https://docs.docker.com/desktop/setup/install/windows-install/";
+pub const GATEWAY_SITE_URL: &str = "https://vocagateway.vocahq.com";
+
+const COMPOSE_YAML: &str = include_str!("../gateway/compose.yaml");
+const TOKEN_HEX_LEN: usize = 32;
+const DOCKER_BIN: &str = "docker";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GatewayPhase {
+    DockerMissing,
+    Stopped,
+    Starting,
+    LiveNotReady,
+    Ready,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GatewayStatus {
+    pub phase: GatewayPhase,
+    pub phase_label: String,
+    pub docker_available: bool,
+    pub docker_detail: String,
+    pub public_url: String,
+    pub suggested_public_url: String,
+    pub pairable: bool,
+    pub live: bool,
+    pub ready: bool,
+    pub message: String,
+    pub webui_url: String,
+    pub docker_install_url: String,
+    pub gateway_site_url: String,
+    pub image: String,
+    pub release_tag: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GatewayPairing {
+    pub url: String,
+    pub payload: String,
+    pub qr_svg: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PairingResponse {
+    payload: String,
+    url: Option<String>,
+}
+
+/// Reject hosts a phone on another device cannot reach.
+pub fn is_loopback_public_url(raw: &str) -> bool {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let without_scheme = trimmed
+        .strip_prefix("http://")
+        .or_else(|| trimmed.strip_prefix("https://"))
+        .unwrap_or(trimmed);
+    let authority = without_scheme.split('/').next().unwrap_or("").trim();
+    let host = if let Some(rest) = authority.strip_prefix('[') {
+        rest.split(']').next().unwrap_or("").to_ascii_lowercase()
+    } else {
+        authority
+            .split(':')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_ascii_lowercase()
+    };
+    matches!(host.as_str(), "localhost" | "127.0.0.1" | "::1" | "0.0.0.0")
+        || host.starts_with("127.")
+}
+
+pub fn validate_public_url(raw: &str) -> Result<String, String> {
+    let url = raw.trim().to_string();
+    if url.is_empty() {
+        return Err("Set a phone-reachable public URL first (LAN or Tailscale).".into());
+    }
+    if !(url.starts_with("http://") || url.starts_with("https://")) {
+        return Err("Public URL must start with http:// or https://.".into());
+    }
+    if is_loopback_public_url(&url) {
+        return Err(
+            "Do not use 127.0.0.1 or localhost in the public URL. A phone cannot reach that."
+                .into(),
+        );
+    }
+    Ok(url.trim_end_matches('/').to_string())
+}
+
+pub fn generate_token_hex() -> Result<String, String> {
+    let mut bytes = [0u8; TOKEN_HEX_LEN / 2];
+    fill_random(&mut bytes)?;
+    Ok(bytes.iter().map(|b| format!("{b:02x}")).collect())
+}
+
+fn fill_random(buf: &mut [u8]) -> Result<(), String> {
+    getrandom::getrandom(buf).map_err(|error| format!("Could not generate gateway token: {error}"))
+}
+
+pub fn map_phase(docker_available: bool, container_up: bool, live: bool, ready: bool) -> GatewayPhase {
+    if !docker_available {
+        return GatewayPhase::DockerMissing;
+    }
+    if ready {
+        return GatewayPhase::Ready;
+    }
+    if live {
+        return GatewayPhase::LiveNotReady;
+    }
+    if container_up {
+        return GatewayPhase::Starting;
+    }
+    GatewayPhase::Stopped
+}
+
+pub fn phase_label(phase: GatewayPhase) -> &'static str {
+    match phase {
+        GatewayPhase::DockerMissing => "Docker missing",
+        GatewayPhase::Stopped => "Stopped",
+        GatewayPhase::Starting => "Starting",
+        GatewayPhase::LiveNotReady => "Live (not ready)",
+        GatewayPhase::Ready => "Ready",
+    }
+}
+
+pub fn suggest_lan_public_url() -> Option<String> {
+    let socket = UdpSocket::bind("0.0.0.0:0").ok()?;
+    socket.connect("8.8.8.8:80").ok()?;
+    let ip = socket.local_addr().ok()?.ip();
+    if ip.is_loopback() || ip.is_unspecified() {
+        return None;
+    }
+    let candidate = format!("http://{ip}:{PUBLISH_PORT}");
+    if is_loopback_public_url(&candidate) {
+        return None;
+    }
+    Some(candidate)
+}
+
+pub fn gateway_dir(app_data: &Path) -> PathBuf {
+    app_data.join("gateway")
+}
+
+pub fn ensure_gateway_files(dir: &Path, public_url: &str) -> Result<String, String> {
+    fs::create_dir_all(dir).map_err(|error| format!("Could not create gateway directory: {error}"))?;
+    let compose_path = dir.join("compose.yaml");
+    fs::write(&compose_path, COMPOSE_YAML.replace(
+        "ghcr.io/vocahq/vocagateway:v0.1.0",
+        GATEWAY_IMAGE,
+    ))
+    .map_err(|error| format!("Could not write compose.yaml: {error}"))?;
+
+    let env_path = dir.join(".env");
+    let token = read_or_create_token(&env_path)?;
+    write_env_file(&env_path, &token, public_url)?;
+    Ok(token)
+}
+
+fn read_or_create_token(env_path: &Path) -> Result<String, String> {
+    if env_path.exists() {
+        if let Some(existing) = parse_env_value(&fs::read_to_string(env_path).unwrap_or_default(), "VOCAGATEWAY_TOKEN")
+        {
+            if existing.len() >= TOKEN_HEX_LEN {
+                return Ok(existing);
+            }
+        }
+    }
+    generate_token_hex()
+}
+
+fn write_env_file(path: &Path, token: &str, public_url: &str) -> Result<(), String> {
+    let mut body = String::new();
+    body.push_str(&format!("VOCAGATEWAY_TOKEN={token}\n"));
+    body.push_str(&format!("VOCAGATEWAY_PUBLISH_HOST={PUBLISH_HOST}\n"));
+    body.push_str(&format!("VOCAGATEWAY_PUBLISH_PORT={PUBLISH_PORT}\n"));
+    body.push_str(&format!("VOCAGATEWAY_PORT={PUBLISH_PORT}\n"));
+    body.push_str(&format!("VOCAGATEWAY_IMAGE={GATEWAY_IMAGE}\n"));
+    if !public_url.trim().is_empty() {
+        body.push_str(&format!("VOCAGATEWAY_PUBLIC_URL={}\n", public_url.trim()));
+    }
+    write_restricted(path, &body)
+}
+
+fn write_restricted(path: &Path, contents: &str) -> Result<(), String> {
+    fs::write(path, contents).map_err(|error| format!("Could not write {}: {error}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = fs::Permissions::from_mode(0o600);
+        fs::set_permissions(path, perms)
+            .map_err(|error| format!("Could not restrict {}: {error}", path.display()))?;
+    }
+    Ok(())
+}
+
+pub fn parse_env_value(contents: &str, key: &str) -> Option<String> {
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((name, value)) = line.split_once('=') {
+            if name.trim() == key {
+                return Some(value.trim().trim_matches('"').to_string());
+            }
+        }
+    }
+    None
+}
+
+pub fn read_token(dir: &Path) -> Option<String> {
+    let contents = fs::read_to_string(dir.join(".env")).ok()?;
+    parse_env_value(&contents, "VOCAGATEWAY_TOKEN").filter(|t| t.len() >= TOKEN_HEX_LEN)
+}
+
+fn docker_command(args: &[&str]) -> Command {
+    let mut command = Command::new(DOCKER_BIN);
+    command.args(args);
+    command
+}
+
+pub fn detect_docker() -> (bool, String) {
+    let version = match docker_command(&["version"]).output() {
+        Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .find(|line| line.to_ascii_lowercase().contains("server"))
+            .unwrap_or("Docker engine reachable")
+            .trim()
+            .to_string(),
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return (
+                false,
+                if stderr.trim().is_empty() {
+                    "Docker is installed but the engine is not running. Start Docker Desktop.".into()
+                } else {
+                    format!("Docker engine not ready: {}", stderr.trim())
+                },
+            );
+        }
+        Err(_) => {
+            return (
+                false,
+                "Docker Desktop was not found. Install it (WSL2 required), then try again.".into(),
+            );
+        }
+    };
+
+    match docker_command(&["compose", "version"]).output() {
+        Ok(output) if output.status.success() => {
+            let compose = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            (
+                true,
+                if compose.is_empty() {
+                    version
+                } else {
+                    format!("{version}; {compose}")
+                },
+            )
+        }
+        _ => (
+            false,
+            "Docker is present but Compose is missing. Update Docker Desktop.".into(),
+        ),
+    }
+}
+
+fn compose_file_args(dir: &Path) -> Result<(PathBuf, PathBuf), String> {
+    let compose = dir.join("compose.yaml");
+    let env = dir.join(".env");
+    if !compose.exists() {
+        return Err("Gateway compose.yaml is missing. Click Start to recreate it.".into());
+    }
+    if !env.exists() {
+        return Err("Gateway .env is missing. Click Start to recreate it.".into());
+    }
+    Ok((compose, env))
+}
+
+fn run_compose(dir: &Path, subcommand: &[&str]) -> Result<String, String> {
+    let (compose, env) = compose_file_args(dir)?;
+    let compose_str = compose.to_string_lossy();
+    let env_str = env.to_string_lossy();
+    let mut args = vec![
+        "compose",
+        "-p",
+        COMPOSE_PROJECT,
+        "-f",
+        compose_str.as_ref(),
+        "--env-file",
+        env_str.as_ref(),
+    ];
+    args.extend_from_slice(subcommand);
+    let output = docker_command(&args)
+        .current_dir(dir)
+        .output()
+        .map_err(|error| format!("Could not run docker compose: {error}"))?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let detail = if stderr.trim().is_empty() {
+            stdout.trim()
+        } else {
+            stderr.trim()
+        };
+        Err(format!("docker compose failed: {detail}"))
+    }
+}
+
+pub fn container_running(dir: &Path) -> bool {
+    let (compose, env) = match compose_file_args(dir) {
+        Ok(paths) => paths,
+        Err(_) => return false,
+    };
+    let compose_str = compose.to_string_lossy();
+    let env_str = env.to_string_lossy();
+    let output = docker_command(&[
+        "compose",
+        "-p",
+        COMPOSE_PROJECT,
+        "-f",
+        compose_str.as_ref(),
+        "--env-file",
+        env_str.as_ref(),
+        "ps",
+        "-q",
+        COMPOSE_SERVICE,
+    ])
+    .current_dir(dir)
+    .output();
+    match output {
+        Ok(output) if output.status.success() => {
+            !String::from_utf8_lossy(&output.stdout).trim().is_empty()
+        }
+        _ => false,
+    }
+}
+
+async fn probe_status(path: &str) -> (bool, u16) {
+    let url = format!("{LOCAL_BASE_URL}{path}");
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+    {
+        Ok(client) => client,
+        Err(_) => return (false, 0),
+    };
+    match client.get(&url).send().await {
+        Ok(response) => {
+            let code = response.status().as_u16();
+            (response.status().is_success(), code)
+        }
+        Err(_) => (false, 0),
+    }
+}
+
+pub async fn probe_live_ready() -> (bool, bool) {
+    let (live_ok, _) = probe_status("/health/live").await;
+    let (ready_ok, ready_code) = probe_status("/health/ready").await;
+    // 503 on /health/ready still means the process answered (pairable-before-ready).
+    let live = live_ok || ready_ok || ready_code == 503;
+    (live, ready_ok)
+}
+
+pub async fn status(dir: &Path, public_url: &str) -> GatewayStatus {
+    let (docker_available, docker_detail) = detect_docker();
+    let suggested = suggest_lan_public_url().unwrap_or_default();
+    let public = public_url.trim().to_string();
+    let container_up = docker_available && container_running(dir);
+    let (live, ready) = if docker_available {
+        probe_live_ready().await
+    } else {
+        (false, false)
+    };
+    let phase = map_phase(docker_available, container_up, live, ready);
+    let token_ok = read_token(dir).is_some();
+    let url_ok = !public.is_empty() && !is_loopback_public_url(&public);
+    let pairable = live && url_ok && token_ok;
+    let message = match phase {
+        GatewayPhase::DockerMissing => {
+            "Install Docker Desktop for Windows (WSL2 required), then return here.".into()
+        }
+        GatewayPhase::Stopped => {
+            if public.is_empty() {
+                "Set a non-loopback public URL, then Start.".into()
+            } else if is_loopback_public_url(&public) {
+                "Replace localhost/127.0.0.1 with a LAN or Tailscale URL.".into()
+            } else {
+                "Gateway is stopped.".into()
+            }
+        }
+        GatewayPhase::Starting => "Container is up. Waiting for /health/live...".into(),
+        GatewayPhase::LiveNotReady => {
+            "Gateway is live. Model may still be downloading. Pairing can work before Ready.".into()
+        }
+        GatewayPhase::Ready => "Gateway is ready for dictation clients.".into(),
+    };
+    GatewayStatus {
+        phase,
+        phase_label: phase_label(phase).into(),
+        docker_available,
+        docker_detail,
+        public_url: public,
+        suggested_public_url: suggested,
+        pairable,
+        live,
+        ready,
+        message,
+        webui_url: WEBUI_URL.into(),
+        docker_install_url: DOCKER_DESKTOP_INSTALL_URL.into(),
+        gateway_site_url: GATEWAY_SITE_URL.into(),
+        image: GATEWAY_IMAGE.into(),
+        release_tag: GATEWAY_RELEASE_TAG.into(),
+    }
+}
+
+pub fn start(dir: &Path, public_url: &str) -> Result<(), String> {
+    let (docker_ok, detail) = detect_docker();
+    if !docker_ok {
+        return Err(detail);
+    }
+    let url = validate_public_url(public_url)?;
+    ensure_gateway_files(dir, &url)?;
+    // Prefer a registry pull of the pinned tag. If GHCR has no public image yet,
+    // operators can shallow-clone tag GATEWAY_RELEASE_TAG into this directory and
+    // run `docker compose … up -d --build` (see docs/gateway-embed.md).
+    let _ = run_compose(dir, &["pull", COMPOSE_SERVICE]);
+    run_compose(dir, &["up", "-d", COMPOSE_SERVICE]).map(|_| ())
+}
+
+pub fn stop(dir: &Path) -> Result<(), String> {
+    let (docker_ok, detail) = detect_docker();
+    if !docker_ok {
+        return Err(detail);
+    }
+    if !dir.join("compose.yaml").exists() {
+        return Ok(());
+    }
+    // Never pass --volumes; model data in the named volume must survive Stop.
+    run_compose(dir, &["down"]).map(|_| ())
+}
+
+pub fn set_public_url(dir: &Path, public_url: &str) -> Result<String, String> {
+    let url = if public_url.trim().is_empty() {
+        String::new()
+    } else {
+        validate_public_url(public_url)?
+    };
+    if dir.exists() || !url.is_empty() {
+        let _ = ensure_gateway_files(dir, &url);
+    }
+    Ok(url)
+}
+
+pub async fn pairing(dir: &Path, public_url: &str) -> Result<GatewayPairing, String> {
+    let url = validate_public_url(public_url)?;
+    let token = read_token(dir).ok_or_else(|| {
+        "Gateway token is missing. Start Gateway once to create the .env file.".to_string()
+    })?;
+    let (live, _) = probe_live_ready().await;
+    if !live {
+        return Err("Gateway is not live yet. Wait until status is Live or Ready.".into());
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|error| format!("Could not build HTTP client: {error}"))?;
+    let endpoint = format!(
+        "{LOCAL_BASE_URL}/v1/admin/pairing?url={}",
+        urlencoding_minimal(&url)
+    );
+    let response = client
+        .get(&endpoint)
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .map_err(|error| format!("Pairing request failed: {error}"))?;
+    if !response.status().is_success() {
+        return Err(format!("Pairing returned HTTP {}", response.status()));
+    }
+    let body = response
+        .text()
+        .await
+        .map_err(|error| format!("Pairing body unreadable: {error}"))?;
+    let parsed: PairingResponse = serde_json::from_str(&body)
+        .map_err(|error| format!("Pairing JSON invalid: {error}"))?;
+    if let Ok(decoded) = decode_pairing_payload_url(&parsed.payload) {
+        if is_loopback_public_url(&decoded) {
+            return Err(
+                "Pairing payload still has a loopback URL. Check VOCAGATEWAY_PUBLIC_URL.".into(),
+            );
+        }
+    }
+    let qr_svg = fetch_qr_svg(&client, &token, &url).await;
+    Ok(GatewayPairing {
+        url: parsed.url.unwrap_or(url),
+        payload: parsed.payload,
+        qr_svg,
+    })
+}
+
+fn urlencoding_minimal(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+fn decode_pairing_payload_url(payload: &str) -> Result<String, String> {
+    // Payload is base64url JSON {"v":1,"url":"...","token":"..."}. Avoid a base64
+    // crate: only need to reject loopback when we can decode; otherwise skip.
+    let normalized = payload.replace('-', "+").replace('_', "/");
+    let padded = match normalized.len() % 4 {
+        0 => normalized,
+        2 => format!("{normalized}=="),
+        3 => format!("{normalized}="),
+        _ => return Err("bad padding".into()),
+    };
+    let bytes = decode_base64(&padded)?;
+    let json: serde_json::Value = serde_json::from_slice(&bytes).map_err(|e| e.to_string())?;
+    json.get("url")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| "missing url".into())
+}
+
+fn decode_base64(input: &str) -> Result<Vec<u8>, String> {
+    // Minimal standard base64 decoder for pairing payload checks.
+    fn val(c: u8) -> Option<u8> {
+        match c {
+            b'A'..=b'Z' => Some(c - b'A'),
+            b'a'..=b'z' => Some(c - b'a' + 26),
+            b'0'..=b'9' => Some(c - b'0' + 52),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            _ => None,
+        }
+    }
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len() / 4 * 3);
+    let mut i = 0;
+    while i + 4 <= bytes.len() {
+        let a = if bytes[i] == b'=' {
+            0
+        } else {
+            val(bytes[i]).ok_or("bad base64")?
+        };
+        let b = if bytes[i + 1] == b'=' {
+            0
+        } else {
+            val(bytes[i + 1]).ok_or("bad base64")?
+        };
+        let c = if bytes[i + 2] == b'=' {
+            0
+        } else {
+            val(bytes[i + 2]).ok_or("bad base64")?
+        };
+        let d = if bytes[i + 3] == b'=' {
+            0
+        } else {
+            val(bytes[i + 3]).ok_or("bad base64")?
+        };
+        out.push((a << 2) | (b >> 4));
+        if bytes[i + 2] != b'=' {
+            out.push((b << 4) | (c >> 2));
+        }
+        if bytes[i + 3] != b'=' {
+            out.push((c << 6) | d);
+        }
+        i += 4;
+    }
+    Ok(out)
+}
+
+async fn fetch_qr_svg(client: &reqwest::Client, token: &str, public_url: &str) -> Option<String> {
+    let endpoint = format!(
+        "{LOCAL_BASE_URL}/v1/admin/pairing/qr.svg?url={}",
+        urlencoding_minimal(public_url)
+    );
+    let response = client
+        .get(&endpoint)
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let text = response.text().await.ok()?;
+    if text.contains("<svg") {
+        Some(text)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_loopback_hosts() {
+        assert!(is_loopback_public_url("http://127.0.0.1:8765"));
+        assert!(is_loopback_public_url("http://localhost:8765"));
+        assert!(is_loopback_public_url("https://127.0.0.1/"));
+        assert!(is_loopback_public_url("http://127.1.2.3:8765"));
+        assert!(is_loopback_public_url("http://[::1]:8765"));
+        assert!(!is_loopback_public_url("http://192.168.1.20:8765"));
+        assert!(!is_loopback_public_url("http://100.64.1.2:8765"));
+        assert!(!is_loopback_public_url(""));
+    }
+
+    #[test]
+    fn validate_public_url_requires_scheme_and_non_loopback() {
+        assert!(validate_public_url("192.168.1.20:8765").is_err());
+        assert!(validate_public_url("http://127.0.0.1:8765").is_err());
+        assert_eq!(
+            validate_public_url("http://192.168.1.20:8765/").unwrap(),
+            "http://192.168.1.20:8765"
+        );
+    }
+
+    #[test]
+    fn token_is_at_least_32_hex() {
+        let token = generate_token_hex().expect("entropy");
+        assert!(token.len() >= 32);
+        assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn phase_mapping_covers_contract_states() {
+        assert_eq!(
+            map_phase(false, false, false, false),
+            GatewayPhase::DockerMissing
+        );
+        assert_eq!(map_phase(true, false, false, false), GatewayPhase::Stopped);
+        assert_eq!(
+            map_phase(true, true, false, false),
+            GatewayPhase::Starting
+        );
+        assert_eq!(
+            map_phase(true, true, true, false),
+            GatewayPhase::LiveNotReady
+        );
+        assert_eq!(map_phase(true, true, true, true), GatewayPhase::Ready);
+        assert_eq!(map_phase(true, false, true, true), GatewayPhase::Ready);
+    }
+
+    #[test]
+    fn parse_env_reads_token() {
+        let sample = "VOCAGATEWAY_PUBLISH_PORT=8765\nVOCAGATEWAY_TOKEN=abcd\n";
+        assert_eq!(
+            parse_env_value(sample, "VOCAGATEWAY_TOKEN").as_deref(),
+            Some("abcd")
+        );
+    }
+
+    #[test]
+    fn compose_yaml_pins_release_image() {
+        assert!(COMPOSE_YAML.contains(GATEWAY_IMAGE) || COMPOSE_YAML.contains("v0.1.0"));
+        assert!(!COMPOSE_YAML.contains(":latest"));
+        assert!(COMPOSE_YAML.contains("service") || COMPOSE_YAML.contains("gateway:"));
+    }
+}

--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -100,6 +100,15 @@ pub fn validate_public_url(raw: &str) -> Result<String, String> {
     if url.is_empty() {
         return Err("Set a phone-reachable public URL first (LAN or Tailscale).".into());
     }
+    // Defend .env writes: reject CR/LF and other characters that can inject keys
+    // or break Compose env parsing when the value is written unquoted.
+    if url.chars().any(|c| {
+        c.is_control()
+            || c.is_whitespace()
+            || matches!(c, '#' | '"' | '\'' | '`' | '$' | '=' | '@' | '\\' | ';')
+    }) {
+        return Err("Public URL contains invalid characters.".into());
+    }
     if !(url.starts_with("http://") || url.starts_with("https://")) {
         return Err("Public URL must start with http:// or https://.".into());
     }
@@ -519,9 +528,15 @@ pub async fn pairing(dir: &Path, public_url: &str) -> Result<GatewayPairing, Str
             );
         }
     }
-    let qr_svg = fetch_qr_svg(&client, &token, &url).await;
+    let display_url = parsed.url.unwrap_or(url);
+    if is_loopback_public_url(&display_url) {
+        return Err(
+            "Pairing response returned a loopback URL. Check VOCAGATEWAY_PUBLIC_URL.".into(),
+        );
+    }
+    let qr_svg = fetch_qr_svg(&client, &token, &display_url).await;
     Ok(GatewayPairing {
-        url: parsed.url.unwrap_or(url),
+        url: display_url,
         qr_svg,
     })
 }
@@ -647,6 +662,9 @@ mod tests {
     fn validate_public_url_requires_scheme_and_non_loopback() {
         assert!(validate_public_url("192.168.1.20:8765").is_err());
         assert!(validate_public_url("http://127.0.0.1:8765").is_err());
+        assert!(validate_public_url("http://192.168.1.20:8765\nVOCAGATEWAY_TOKEN=ab").is_err());
+        assert!(validate_public_url("http://192.168.1.20:8765#frag").is_err());
+        assert!(validate_public_url("http://192.168.1.20@127.0.0.1:8765").is_err());
         assert_eq!(
             validate_public_url("http://192.168.1.20:8765/").unwrap(),
             "http://192.168.1.20:8765"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod autopause;
 mod devices;
+mod gateway;
 mod gpu;
 mod hardware;
 mod hook;
@@ -246,6 +247,12 @@ struct Settings {
     /// Off by default so insertion does not take over whatever was copied.
     #[serde(default)]
     copy_to_clipboard: bool,
+    /// Opt-in Settings → Gateway preference. Does not route VocaWin dictation.
+    #[serde(default)]
+    gateway_enabled: bool,
+    /// Phone-reachable non-loopback base URL written into Gateway `.env`.
+    #[serde(default)]
+    gateway_public_url: String,
 }
 
 fn default_true() -> bool {
@@ -284,6 +291,8 @@ impl Default for Settings {
             debug_logging: false,
             custom_vocabulary: String::new(),
             copy_to_clipboard: false,
+            gateway_enabled: false,
+            gateway_public_url: String::new(),
         }
     }
 }
@@ -918,6 +927,8 @@ struct AppState {
     settings_path: PathBuf,
     history_path: PathBuf,
     models_path: PathBuf,
+    /// Compose project dir: `%APPDATA%/com.vocahq.vocawin/gateway/`.
+    gateway_path: PathBuf,
     downloads: Mutex<HashMap<String, ModelInstallStatus>>,
     recorder: AudioRecorder,
     recording: Mutex<bool>,
@@ -1036,6 +1047,12 @@ fn save_settings(
         settings.auto_pause_enabled = false;
     } else {
         settings.auto_pause_enabled = true;
+    }
+    if !settings.gateway_public_url.trim().is_empty() {
+        settings.gateway_public_url = gateway::validate_public_url(&settings.gateway_public_url)?;
+        let _ = gateway::set_public_url(&state.gateway_path, &settings.gateway_public_url);
+    } else {
+        settings.gateway_public_url.clear();
     }
     sounds::apply_theme(&mut settings.sound_theme, &mut settings.sound_effects);
     settings.hotkey = hotkey::canonicalize(&settings.hotkey)?;
@@ -2348,13 +2365,76 @@ fn allowed_external_url(url: &str) -> bool {
         "https://vocamac.com",
         "https://vocaphone.vocahq.com",
         "https://vocagateway.vocahq.com",
+        "https://docs.docker.com/desktop/setup/install/windows-install/",
         "https://discord.gg/t6muquAJbm",
         "https://x.com/vocahq",
         "https://github.com/VocaHQ/vocawin",
         "https://github.com/VocaHQ/vocawin/issues/new/choose",
+        "http://127.0.0.1:8765/",
+        "http://127.0.0.1:8765",
         "mailto:hello@vocahq.com",
     ];
     ALLOWED.contains(&url)
+}
+
+#[tauri::command]
+async fn gateway_status(state: State<'_, AppState>) -> Result<gateway::GatewayStatus, String> {
+    let public_url = state
+        .settings
+        .lock()
+        .map(|settings| settings.gateway_public_url.clone())
+        .map_err(|_| "Settings lock was poisoned".to_string())?;
+    Ok(gateway::status(&state.gateway_path, &public_url).await)
+}
+
+#[tauri::command]
+fn gateway_start(state: State<'_, AppState>) -> Result<(), String> {
+    let public_url = {
+        let settings = state
+            .settings
+            .lock()
+            .map_err(|_| "Settings lock was poisoned".to_string())?;
+        if !settings.gateway_enabled {
+            return Err("Turn on Gateway in Settings before starting.".into());
+        }
+        settings.gateway_public_url.clone()
+    };
+    gateway::start(&state.gateway_path, &public_url)
+}
+
+#[tauri::command]
+fn gateway_stop(state: State<'_, AppState>) -> Result<(), String> {
+    gateway::stop(&state.gateway_path)
+}
+
+#[tauri::command]
+fn gateway_set_public_url(
+    url: String,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    let normalized = gateway::set_public_url(&state.gateway_path, &url)?;
+    let mut settings = state
+        .settings
+        .lock()
+        .map_err(|_| "Settings lock was poisoned".to_string())?
+        .clone();
+    settings.gateway_public_url = normalized.clone();
+    persist_settings(&state.settings_path, &settings)?;
+    *state
+        .settings
+        .lock()
+        .map_err(|_| "Settings lock was poisoned".to_string())? = settings;
+    Ok(normalized)
+}
+
+#[tauri::command]
+async fn gateway_pairing(state: State<'_, AppState>) -> Result<gateway::GatewayPairing, String> {
+    let public_url = state
+        .settings
+        .lock()
+        .map(|settings| settings.gateway_public_url.clone())
+        .map_err(|_| "Settings lock was poisoned".to_string())?;
+    gateway::pairing(&state.gateway_path, &public_url).await
 }
 
 #[tauri::command]
@@ -2402,6 +2482,7 @@ pub fn run() {
             let settings_path = app_data.join("settings.json");
             let history_path = app_data.join("history.json");
             let models_path = app_data.join("models");
+            let gateway_path = gateway::gateway_dir(&app_data);
             fs::create_dir_all(&models_path)?;
             let mut settings = load_settings(&settings_path);
             if fallback_selected_model_if_needed(&mut settings, &models_path) {
@@ -2419,6 +2500,7 @@ pub fn run() {
                 settings_path,
                 history_path,
                 models_path,
+                gateway_path,
                 downloads: Mutex::new(HashMap::new()),
                 recorder: AudioRecorder::new(handle.clone()),
                 recording: Mutex::new(false),
@@ -2504,7 +2586,12 @@ pub fn run() {
             preview_sound,
             inject_text,
             copy_text,
-            open_external
+            open_external,
+            gateway_status,
+            gateway_start,
+            gateway_stop,
+            gateway_set_public_url,
+            gateway_pairing
         ])
         .run(tauri::generate_context!())
         .expect("error while running VocaWin");

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,8 @@ type Settings = {
   debugLogging: boolean;
   customVocabulary: string;
   copyToClipboard: boolean;
+  gatewayEnabled: boolean;
+  gatewayPublicUrl: string;
 };
 type View = "dictation" | "models" | "history" | "settings" | "debug" | "about";
 type HistoryEntry = { id: number; text: string; modelId: string; createdAtMs: number };
@@ -66,6 +68,29 @@ type LogLine = { level: string; text: string };
 type RunningApp = { name: string; label: string };
 type EngineFilter = "all" | "whisper" | "onnx";
 type LanguageFilter = "any" | "english" | "multilingual";
+type GatewayPhase = "dockerMissing" | "stopped" | "starting" | "liveNotReady" | "ready";
+type GatewayStatus = {
+  phase: GatewayPhase;
+  phaseLabel: string;
+  dockerAvailable: boolean;
+  dockerDetail: string;
+  publicUrl: string;
+  suggestedPublicUrl: string;
+  pairable: boolean;
+  live: boolean;
+  ready: boolean;
+  message: string;
+  webuiUrl: string;
+  dockerInstallUrl: string;
+  gatewaySiteUrl: string;
+  image: string;
+  releaseTag: string;
+};
+type GatewayPairing = {
+  url: string;
+  payload: string;
+  qrSvg?: string | null;
+};
 
 type SettingsItem = {
   group: "Dictation" | "Audio" | "Application";
@@ -195,6 +220,10 @@ let previewStartNext = true;
 let runningApps: RunningApp[] = [];
 let focusRestore: { id: string; start: number; end: number } | null = null;
 let paneScroll = 0;
+let gatewayStatus: GatewayStatus | null = null;
+let gatewayPairing: GatewayPairing | null = null;
+let gatewayBusy = false;
+let gatewayPollTimer: number | null = null;
 let resetPaneScroll = false;
 let micPeak = 0;
 
@@ -546,6 +575,77 @@ function powerMatches(query: string) {
   return query.split(/\s+/).every(part => hay.includes(part));
 }
 
+function gatewayMatches(query: string) {
+  if (!query) return true;
+  const hay = "gateway docker desktop wsl compose pair qr phone vocagateway public url start stop container not on-device";
+  return query.split(/\s+/).every(part => hay.includes(part));
+}
+
+function gatewaySection() {
+  const status = gatewayStatus;
+  const phase = status?.phaseLabel ?? (settings.gatewayEnabled ? "Checking…" : "Off");
+  const message = status?.message
+    ?? "Optional local VocaGateway for phones and other Voca clients. VocaWin dictation stays on this PC.";
+  const dockerOk = status?.dockerAvailable ?? false;
+  const hasUrl = Boolean((settings.gatewayPublicUrl || "").trim());
+  const canStart = settings.gatewayEnabled && dockerOk && hasUrl && !gatewayBusy;
+  const canStop = settings.gatewayEnabled && dockerOk && !gatewayBusy;
+  const pairable = Boolean(status?.pairable);
+  const publicValue = settings.gatewayPublicUrl || status?.suggestedPublicUrl || "";
+  const dockerLink = status?.dockerInstallUrl
+    ?? "https://docs.docker.com/desktop/setup/install/windows-install/";
+  const siteLink = status?.gatewaySiteUrl ?? "https://vocagateway.vocahq.com";
+  const webui = status?.webuiUrl ?? "http://127.0.0.1:8765/";
+  const qr = gatewayPairing?.qrSvg
+    ? `<div class="gateway-qr" aria-label="Pairing QR">${gatewayPairing.qrSvg}</div>`
+    : "";
+  const pairUrl = gatewayPairing?.url
+    ? `<div class="gateway-pair-url"><code>${escape(gatewayPairing.url)}</code>
+        <button type="button" class="quiet-button" id="gateway-copy-url">Copy URL</button></div>`
+    : pairable
+      ? `<p class="gateway-note">Pairing is available. Refresh if the QR does not appear.</p>`
+      : "";
+
+  return `<section class="settings-card gateway-card" data-settings-group="Gateway"><p class="settings-group">Gateway</p>
+    <div class="gateway-lede about-copy">
+      <p>Optional. Starts a local <button type="button" class="text-button" data-open="${escape(siteLink)}">VocaGateway</button> container so phones and other Voca clients can pair with this PC. This is <strong>not on-device</strong>: audio that uses Gateway leaves this PC for the container. VocaWin’s own dictation still runs locally.</p>
+    </div>
+    <div class="setting-row">
+      <div><strong>Enable Gateway</strong><p>Opt in to manage a local Compose project named vocagateway.</p></div>
+      <label class="switch"><input id="gateway-enabled" type="checkbox" ${settings.gatewayEnabled ? "checked" : ""}/><span></span></label>
+    </div>
+    <div class="setting-row">
+      <div><strong>Status</strong><p>${escape(message)}</p></div>
+      <div class="gateway-status-readout"><strong>${escape(phase)}</strong><span>${escape(status?.dockerDetail || (dockerOk ? "Docker ready" : "Docker Desktop + WSL2 required"))}</span></div>
+    </div>
+    ${dockerOk ? "" : `<div class="setting-row"><div><strong>Docker Desktop</strong><p>Install Docker Desktop for Windows. WSL2 is required. Start stays off until Docker answers.</p></div>
+      <button type="button" class="quiet-button" data-open="${escape(dockerLink)}">Install Docker</button></div>`}
+    <div class="setting-row">
+      <div><strong>Public URL</strong><p>Phone-reachable base URL (LAN or Tailscale). Never 127.0.0.1 or localhost. Required under Docker Desktop.</p></div>
+      <div class="stacked-control">
+        <input id="gateway-public-url" type="url" placeholder="http://192.168.1.20:8765" value="${escape(publicValue)}" ${settings.gatewayEnabled ? "" : "disabled "}/>
+        ${status?.suggestedPublicUrl && !settings.gatewayPublicUrl ? `<button type="button" class="quiet-button" id="gateway-use-suggested">Use suggested</button>` : ""}
+      </div>
+    </div>
+    <div class="setting-row">
+      <div><strong>Container</strong><p>Pinned image ${escape(status?.image ?? "ghcr.io/vocahq/vocagateway:v0.1.0")}. Stop keeps model volumes.</p></div>
+      <div class="status-actions">
+        <button type="button" class="quiet-button" id="gateway-start" ${canStart ? "" : "disabled"}>${gatewayBusy ? "Working…" : "Start"}</button>
+        <button type="button" class="quiet-button" id="gateway-stop" ${canStop ? "" : "disabled"}>Stop</button>
+        <button type="button" class="quiet-button" id="gateway-open-webui" ${status?.live ? "" : "disabled"} data-open="${escape(webui)}">Open WebUI</button>
+      </div>
+    </div>
+    ${pairable || gatewayPairing ? `<div class="gateway-pairing">
+      <p class="settings-group">Pairing</p>
+      <p class="gateway-note">Scan with VocaPhone once Gateway is live. Pairing can work before Ready while a model downloads.</p>
+      ${qr}${pairUrl}
+      <div class="status-actions gateway-pair-actions">
+        <button type="button" class="quiet-button" id="gateway-refresh-pair">Refresh QR</button>
+      </div>
+    </div>` : ""}
+  </section>`;
+}
+
 function powerSection() {
   return `<section class="settings-card power-card" data-settings-group="Power"><p class="settings-group">Power</p>
     <div class="setting-row">
@@ -693,9 +793,10 @@ function settingsPage() {
       </section>`;
   }).join("");
   const power = powerMatches(query) ? powerSection() : "";
+  const gateway = gatewayMatches(query) ? gatewaySection() : "";
   return `<header><div><p class="overline">PREFERENCES</p><h1>Make it <em>yours.</em></h1><p class="lede">VocaWin only stores these choices locally on this PC. Each change is saved as you make it.</p></div></header>
   <div class="settings-search"><input id="settings-search" type="search" placeholder="Search settings" value="${escape(settingsQuery)}" /></div>
-  ${cards}${power || (cards ? "" : `<div class="empty-history">No settings match “${escape(settingsQuery)}”.</div>`)}
+  ${cards}${gateway}${power}${(cards || gateway || power) ? "" : `<div class="empty-history">No settings match “${escape(settingsQuery)}”.</div>`}
   ${recordingHotkey ? `<p class="recording-hint">Press a key combo, or Escape to cancel.</p>` : ""}`;
 }
 
@@ -739,7 +840,7 @@ function aboutPage() {
     <section class="settings-card">
       <p class="settings-group">Part of VocaHQ</p>
       <div class="about-copy">
-        <p>VocaWin is one of the VocaHQ apps. The same private dictation already runs on Linux as VocaLinux, on macOS as VocaMac, and on phones as VocaPhone. VocaGateway is optional self-hosted compute for other Voca clients.</p>
+        <p>VocaWin is one of the VocaHQ apps. The same private dictation already runs on Linux as VocaLinux, on macOS as VocaMac, and on phones as VocaPhone. Settings can optionally start a local VocaGateway container for pairing other clients. Win dictation stays on this PC.</p>
         <ul class="about-links">
           <li><button type="button" class="text-button" data-open="https://vocahq.com">vocahq.com</button></li>
           <li><button type="button" class="text-button" data-open="https://vocalinux.com">vocalinux.com</button></li>
@@ -841,8 +942,12 @@ function render() {
 function openView(next: View) {
   view = next;
   resetPaneScroll = true;
+  stopGatewayPolling();
   if (next === "settings") {
-    void Promise.all([refreshRunningApps(), refreshRuntime()]).then(render);
+    void Promise.all([refreshRunningApps(), refreshRuntime(), refreshGatewayStatus()]).then(() => {
+      render();
+      startGatewayPolling();
+    });
     return;
   }
   if (next === "debug") {
@@ -873,6 +978,7 @@ function bindChrome() {
     void addWatchedApp();
   });
   bindWatchedAppChips();
+  bindGatewayControls();
   bindFilterCombo("#engine-filter", ENGINE_FILTERS, value => { engineFilter = value as EngineFilter; });
   bindFilterCombo("#language-filter", LANGUAGE_FILTERS, value => { languageFilter = value as LanguageFilter; });
   bindLiveSearch("#settings-search", value => { settingsQuery = value; });
@@ -965,13 +1071,13 @@ function bindAutosave() {
     void persistSettings();
   };
   document.querySelectorAll<HTMLElement>(".setting-row input, .setting-row select, .setting-row textarea, #debug-logging, #idle-unload").forEach(node => {
-    if (node.id === "custom-vocabulary" || node.id === "language") {
+    if (node.id === "custom-vocabulary" || node.id === "language" || node.id === "gateway-public-url") {
       node.addEventListener("change", persistFromEvent);
       node.addEventListener("blur", persistFromEvent);
       return;
     }
     node.addEventListener("change", persistFromEvent);
-    if (node instanceof HTMLInputElement && (node.type === "number" || node.type === "search")) {
+    if (node instanceof HTMLInputElement && (node.type === "number" || node.type === "search" || node.type === "url")) {
       node.addEventListener("blur", persistFromEvent);
     }
   });
@@ -1021,6 +1127,10 @@ function collectSettingsFromDom() {
   if (debugLogging) settings.debugLogging = debugLogging.checked;
   const customVocabulary = document.querySelector<HTMLTextAreaElement>("#custom-vocabulary");
   if (customVocabulary) settings.customVocabulary = customVocabulary.value;
+  const gatewayEnabled = document.querySelector<HTMLInputElement>("#gateway-enabled");
+  if (gatewayEnabled) settings.gatewayEnabled = gatewayEnabled.checked;
+  const gatewayPublicUrl = document.querySelector<HTMLInputElement>("#gateway-public-url");
+  if (gatewayPublicUrl) settings.gatewayPublicUrl = gatewayPublicUrl.value.trim();
 }
 
 async function persistSettings(silent = false, skipCollect = false) {
@@ -1098,6 +1208,150 @@ async function removeWatchedApp(name: string) {
   settings.autoPauseEnabled = remaining.length > 0;
   await persistSettings();
   paintPowerApps();
+}
+
+async function refreshGatewayStatus(opts: { quiet?: boolean } = {}) {
+  try {
+    const next = await invoke<GatewayStatus>("gateway_status");
+    const wasPairable = gatewayStatus?.pairable;
+    gatewayStatus = next;
+    if (next.publicUrl && !settings.gatewayPublicUrl) {
+      settings.gatewayPublicUrl = next.publicUrl;
+    }
+    if (next.pairable && (!gatewayPairing || !wasPairable)) {
+      await refreshGatewayPairing(opts);
+    }
+    if (!next.pairable) {
+      gatewayPairing = null;
+    }
+  } catch (error) {
+    if (!opts.quiet) showToast(String(error));
+  }
+}
+
+async function refreshGatewayPairing(opts: { quiet?: boolean } = {}) {
+  try {
+    gatewayPairing = await invoke<GatewayPairing>("gateway_pairing");
+  } catch (error) {
+    gatewayPairing = null;
+    if (!opts.quiet) showToast(String(error));
+  }
+}
+
+function startGatewayPolling() {
+  stopGatewayPolling();
+  if (view !== "settings") return;
+  gatewayPollTimer = window.setInterval(() => {
+    if (view !== "settings" || gatewayBusy) return;
+    const before = JSON.stringify({
+      phase: gatewayStatus?.phase,
+      message: gatewayStatus?.message,
+      pairable: gatewayStatus?.pairable,
+      live: gatewayStatus?.live,
+      ready: gatewayStatus?.ready,
+      docker: gatewayStatus?.dockerAvailable,
+    });
+    void refreshGatewayStatus({ quiet: true }).then(() => {
+      if (view !== "settings") return;
+      const after = JSON.stringify({
+        phase: gatewayStatus?.phase,
+        message: gatewayStatus?.message,
+        pairable: gatewayStatus?.pairable,
+        live: gatewayStatus?.live,
+        ready: gatewayStatus?.ready,
+        docker: gatewayStatus?.dockerAvailable,
+      });
+      if (before !== after) render();
+    });
+  }, 4000);
+}
+
+function stopGatewayPolling() {
+  if (gatewayPollTimer !== null) {
+    window.clearInterval(gatewayPollTimer);
+    gatewayPollTimer = null;
+  }
+}
+
+function bindGatewayControls() {
+  document.querySelector("#gateway-start")?.addEventListener("click", () => {
+    void (async () => {
+      gatewayBusy = true;
+      render();
+      try {
+        collectSettingsFromDom();
+        if (settings.gatewayPublicUrl) {
+          settings.gatewayPublicUrl = await invoke<string>("gateway_set_public_url", {
+            url: settings.gatewayPublicUrl,
+          });
+        }
+        await invoke("gateway_start");
+        showToast("Gateway starting…");
+        await refreshGatewayStatus();
+      } catch (error) {
+        showToast(String(error));
+      } finally {
+        gatewayBusy = false;
+        render();
+        startGatewayPolling();
+      }
+    })();
+  });
+  document.querySelector("#gateway-stop")?.addEventListener("click", () => {
+    void (async () => {
+      gatewayBusy = true;
+      render();
+      try {
+        await invoke("gateway_stop");
+        gatewayPairing = null;
+        showToast("Gateway stopped.");
+        await refreshGatewayStatus({ quiet: true });
+      } catch (error) {
+        showToast(String(error));
+      } finally {
+        gatewayBusy = false;
+        render();
+        startGatewayPolling();
+      }
+    })();
+  });
+  document.querySelector("#gateway-use-suggested")?.addEventListener("click", () => {
+    const suggested = gatewayStatus?.suggestedPublicUrl;
+    if (!suggested) return;
+    settings.gatewayPublicUrl = suggested;
+    const input = document.querySelector<HTMLInputElement>("#gateway-public-url");
+    if (input) input.value = suggested;
+    void (async () => {
+      try {
+        settings.gatewayPublicUrl = await invoke<string>("gateway_set_public_url", { url: suggested });
+        await persistSettings(true, true);
+        showToast("Public URL saved.");
+        render();
+      } catch (error) {
+        showToast(String(error));
+      }
+    })();
+  });
+  document.querySelector("#gateway-refresh-pair")?.addEventListener("click", () => {
+    void refreshGatewayPairing().then(render);
+  });
+  document.querySelector("#gateway-copy-url")?.addEventListener("click", () => {
+    const url = gatewayPairing?.url;
+    if (!url) return;
+    void (async () => {
+      try {
+        await invoke("copy_text", { text: url });
+        showToast("Pairing URL copied.");
+      } catch {
+        try {
+          await navigator.clipboard.writeText(url);
+          showToast("Pairing URL copied.");
+        } catch {
+          showToast("Could not copy pairing URL.");
+        }
+      }
+    })();
+  });
 }
 
 async function openExternal(url: string) {
@@ -1456,6 +1710,8 @@ Promise.all([
     debugLogging: saved.debugLogging ?? false,
     customVocabulary: saved.customVocabulary ?? "",
     copyToClipboard: saved.copyToClipboard ?? false,
+    gatewayEnabled: saved.gatewayEnabled ?? false,
+    gatewayPublicUrl: saved.gatewayPublicUrl ?? "",
   };
   statuses = installs;
   history = entries;

--- a/src/main.ts
+++ b/src/main.ts
@@ -226,15 +226,16 @@ let gatewayPollTimer: number | null = null;
 let resetPaneScroll = false;
 let micPeak = 0;
 
-const escape = (value: string) => value.replace(/[&<>"]/g, c => ({ "&": "&amp;
+const escape = (value: string) => value.replace(/[&<>"]/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]!));
 /** Gateway QR SVG only. Strip script-ish markup before innerHTML. */
 const sanitizeGatewayQrSvg = (svg: string) => {
   if (!svg.includes("<svg")) return "";
   return svg
     .replace(/<script\b[\s\S]*?<\/script>/gi, "")
     .replace(/\son[a-z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, "")
+    .replace(/javascript\s*:/gi, "")
     .replace(/<foreignObject\b[\s\S]*?<\/foreignObject>/gi, "");
-};", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]!));
+};
 const selected = () => models.find(model => model.id === settings.selectedModel);
 const modelInstalled = () => !!statuses[settings.selectedModel]?.installed;
 const formatBytes = (bytes?: number) => {
@@ -594,8 +595,10 @@ function gatewaySection() {
   const message = status?.message
     ?? "Optional local VocaGateway for phones and other Voca clients. VocaWin dictation stays on this PC.";
   const dockerOk = status?.dockerAvailable ?? false;
-  const hasUrl = Boolean((settings.gatewayPublicUrl || "").trim());
-  const canStart = settings.gatewayEnabled && dockerOk && hasUrl && !gatewayBusy;
+  const publicUrlTrimmed = (settings.gatewayPublicUrl || "").trim();
+  const hasUrl = Boolean(publicUrlTrimmed);
+  const urlLooksLoopback = /:\/\/(localhost|127\.|\[::1\]|0\.0\.0\.0)\b/i.test(publicUrlTrimmed);
+  const canStart = settings.gatewayEnabled && dockerOk && hasUrl && !urlLooksLoopback && !gatewayBusy;
   const canStop = settings.gatewayEnabled && dockerOk && !gatewayBusy;
   const pairable = Boolean(status?.pairable);
   const publicValue = settings.gatewayPublicUrl || status?.suggestedPublicUrl || "";
@@ -1157,6 +1160,12 @@ async function persistSettings(silent = false, skipCollect = false) {
     if (!silent) showToast("Settings saved");
   } catch (error) {
     showToast(String(error));
+    try {
+      settings = await invoke<Settings>("get_settings");
+      render();
+    } catch {
+      /* keep prior in-memory settings if reload fails */
+    }
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,7 +88,6 @@ type GatewayStatus = {
 };
 type GatewayPairing = {
   url: string;
-  payload: string;
   qrSvg?: string | null;
 };
 
@@ -227,7 +226,15 @@ let gatewayPollTimer: number | null = null;
 let resetPaneScroll = false;
 let micPeak = 0;
 
-const escape = (value: string) => value.replace(/[&<>"]/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]!));
+const escape = (value: string) => value.replace(/[&<>"]/g, c => ({ "&": "&amp;
+/** Gateway QR SVG only. Strip script-ish markup before innerHTML. */
+const sanitizeGatewayQrSvg = (svg: string) => {
+  if (!svg.includes("<svg")) return "";
+  return svg
+    .replace(/<script\b[\s\S]*?<\/script>/gi, "")
+    .replace(/\son[a-z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, "")
+    .replace(/<foreignObject\b[\s\S]*?<\/foreignObject>/gi, "");
+};", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]!));
 const selected = () => models.find(model => model.id === settings.selectedModel);
 const modelInstalled = () => !!statuses[settings.selectedModel]?.installed;
 const formatBytes = (bytes?: number) => {
@@ -596,8 +603,9 @@ function gatewaySection() {
     ?? "https://docs.docker.com/desktop/setup/install/windows-install/";
   const siteLink = status?.gatewaySiteUrl ?? "https://vocagateway.vocahq.com";
   const webui = status?.webuiUrl ?? "http://127.0.0.1:8765/";
-  const qr = gatewayPairing?.qrSvg
-    ? `<div class="gateway-qr" aria-label="Pairing QR">${gatewayPairing.qrSvg}</div>`
+  const qrSvg = gatewayPairing?.qrSvg ? sanitizeGatewayQrSvg(gatewayPairing.qrSvg) : "";
+  const qr = qrSvg
+    ? `<div class="gateway-qr" aria-label="Pairing QR">${qrSvg}</div>`
     : "";
   const pairUrl = gatewayPairing?.url
     ? `<div class="gateway-pair-url"><code>${escape(gatewayPairing.url)}</code>

--- a/src/style.css
+++ b/src/style.css
@@ -175,5 +175,3 @@ main{height:100vh;overflow-y:auto;padding:36px 48px 48px;position:relative;--scr
   .gateway-pairing,.gateway-qr{border-color:#3c403d}
   .gateway-qr{background:#292c29}
 }
-
-.gateway-lede{padding:4px 22px 12px}.gateway-lede p{margin:0;color:#5a615d;font-size:12px;line-height:1.55}.gateway-lede .text-button{margin:0;display:inline;font-size:inherit}.gateway-status-readout{text-align:right;max-width:240px}.gateway-status-readout strong,.gateway-status-readout span{display:block}.gateway-status-readout span{margin-top:4px;color:#5a615d;font-size:11px;font-weight:400}.gateway-pairing{padding:8px 22px 18px;border-top:1px solid #e3e9e5}.gateway-note{margin:0 0 12px;color:#5a615d;font-size:12px;line-height:1.45}.gateway-qr{width:min(220px,100

--- a/src/style.css
+++ b/src/style.css
@@ -156,3 +156,24 @@ main{height:100vh;overflow-y:auto;padding:36px 48px 48px;position:relative;--scr
   .about-talk-btn:hover{background:#34463d}
   .about-talk-btn:focus-visible{outline-color:#77d0b2}
 }
+
+.gateway-lede{padding:4px 22px 12px}
+.gateway-lede p{margin:0;color:#5a615d;font-size:12px;line-height:1.55}
+.gateway-lede .text-button{margin:0;display:inline;font-size:inherit}
+.gateway-status-readout{text-align:right;max-width:240px}
+.gateway-status-readout strong,.gateway-status-readout span{display:block}
+.gateway-status-readout span{margin-top:4px;color:#5a615d;font-size:11px;font-weight:400}
+.gateway-pairing{padding:8px 22px 18px;border-top:1px solid #e3e9e5}
+.gateway-note{margin:0 0 12px;color:#5a615d;font-size:12px;line-height:1.45}
+.gateway-qr{width:min(220px,100%);margin:0 0 12px;background:#fff;border:1px solid #e3e9e5;border-radius:10px;padding:10px}
+.gateway-qr svg{display:block;width:100%;height:auto}
+.gateway-pair-url{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:10px}
+.gateway-pair-url code{font-size:11px;word-break:break-all}
+.gateway-pair-actions{justify-content:flex-start;padding-top:4px}
+@media(prefers-color-scheme:dark){
+  .gateway-lede p,.gateway-note,.gateway-status-readout span{color:#c2c8c3}
+  .gateway-pairing,.gateway-qr{border-color:#3c403d}
+  .gateway-qr{background:#292c29}
+}
+
+.gateway-lede{padding:4px 22px 12px}.gateway-lede p{margin:0;color:#5a615d;font-size:12px;line-height:1.55}.gateway-lede .text-button{margin:0;display:inline;font-size:inherit}.gateway-status-readout{text-align:right;max-width:240px}.gateway-status-readout strong,.gateway-status-readout span{display:block}.gateway-status-readout span{margin-top:4px;color:#5a615d;font-size:11px;font-weight:400}.gateway-pairing{padding:8px 22px 18px;border-top:1px solid #e3e9e5}.gateway-note{margin:0 0 12px;color:#5a615d;font-size:12px;line-height:1.45}.gateway-qr{width:min(220px,100

--- a/web/index.html
+++ b/web/index.html
@@ -350,8 +350,9 @@
             <h3>Windows is one desk in a larger room.</h3>
             <p>
               VocaLinux, VocaMac, and VocaPhone already exist for other
-              machines. VocaGateway is optional self-hosted compute for those
-              clients. VocaWin does not offer a gateway mode today. The shared
+              machines. VocaGateway is optional self-hosted compute. VocaWin
+              can start a local Gateway container from Settings for pairing
+              other clients; Win dictation stays on this PC. The shared
               home is
               <a href="https://vocahq.com/">vocahq.com</a>.
             </p>
@@ -472,8 +473,9 @@
               <h2 id="privacy-title">on this Windows PC.<br />not a Voca cloud.</h2>
               <p>
                 The beta records with WASAPI on this machine and runs a local
-                speech-to-text model. That is on-device. It is not self-hosted
-                gateway mode, and it is not a hosted speech API.
+                speech-to-text model. That is on-device. It is not a hosted
+                speech API. An optional local Gateway container is separate and
+                is not on-device.
               </p>
               <div class="gateway-paths">
                 <article class="gateway-path">
@@ -738,10 +740,11 @@
           <details>
             <summary>Do I need VocaGateway?<span aria-hidden="true">＋</span></summary>
             <p>
-              Not for VocaWin. VocaWin is an on-device Windows app. VocaGateway
-              is optional self-hosted infrastructure for other Voca clients.
-              Gateway mode is not on-device: configured audio travels to the
-              host you chose.
+              Not for VocaWin dictation. VocaWin speech-to-text stays on this
+              PC. Settings can optionally start a local VocaGateway container
+              so phones and other clients can pair with this machine.
+              Gateway is not on-device: audio that uses it leaves this PC for
+              the container.
             </p>
           </details>
           <details>

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -87,8 +87,8 @@ test("privacy language states where processing happens", () => {
   assert.match(html, /on-device/i);
   assert.match(html, /first model download/i);
   assert.match(html, /not a Voca cloud/i);
-  assert.match(html, /VocaWin does not offer a gateway mode today/i);
-  assert.match(html, /Gateway mode is not on-device/i);
+  assert.match(html, /VocaWin[\s\S]*local Gateway container from Settings/i);
+  assert.match(html, /Gateway is not on-device/i);
 });
 
 test("vocahq.com and the family are linked", () => {


### PR DESCRIPTION
## Summary
Opt-in Settings group that can start a local VocaGateway Compose project on Windows (Docker Desktop + WSL2). Phones and other Voca clients can pair with this PC. VocaWin dictation does not use Gateway and stays on-device.

Frozen contract (HQ): MVP-A Compose-primary. Pin `ghcr.io/vocahq/vocagateway:v0.1.0`. Live/ready polls. Pairable before Ready. Never put loopback in the QR. `PUBLISH_HOST=0.0.0.0`. `down` without `--volumes`.

## What landed
- `src-tauri/src/gateway.rs` plus vendored `src-tauri/gateway/compose.yaml`
- Tauri commands: status, start, stop, set public URL, pairing (+ QR SVG)
- Settings UI: enable, Docker missing link, public URL, start/stop, status, WebUI, QR
- `docs/gateway-embed.md`
- Honesty updates on README, AGENTS, vocawin.com FAQ/family copy
- Unit tests for loopback rejection, token length, phase mapping
- Follow-up: pairing payload/token stays in Rust; Settings only gets URL + sanitized QR

## Residual risks (private review)
- GHCR may still require auth or lack a public `v0.1.0` image; Start tries `pull` then `up -d`. Fallback is documented (shallow clone + `--build`).
- `.env` mode `0600` is Unix-only; Windows ACLs not tightened in MVP.
- Status polling shells out to `docker` often; fine for beta, watch Trooper cost later.
- Store/MSIX and Authenticode stay out of scope (signing path B = Jatin buy).

## Test plan
- [ ] No Docker: Start disabled, install link works
- [ ] Docker up, set LAN URL, Start → live, QR before model Ready
- [ ] Stop leaves named volume (models survive)
- [ ] Loopback public URL rejected
- [ ] Win dictation still local with Gateway running
- [ ] DevTools: no pairing payload/token in Settings IPC

Stay draft. No merge. Hold for CI + Greptile when credits allow.