### PR TITLE
release: prep 0.1.1-beta with Latest (not prerelease) tag cut

### DIFF
--- a/.github/workflows/windows-alpha-release.yml
+++ b/.github/workflows/windows-alpha-release.yml
@@ -1,14 +1,15 @@
-# Windows tagged prerelease for testers. Unsigned installers.
+# Windows tagged release for testers. Unsigned installers.
 # Not a purchased CA / store build. vocawin.com points at GitHub Releases.
 #
 # Tag push is the only trigger. windows-ci.yml must never set tagName.
 # PRs only cargo test. Main uploads the installer artifact.
-# Nightlies are a different tag (`nightly`) in nightly.yml.
-# Always prerelease: a GitHub Release here is not a public ship.
+# Nightlies are a different tag (`nightly`) in nightly.yml and stay prerelease.
+# Named v* cuts publish as Latest (prerelease: false) so they show on the repo homepage.
+# Product status stays beta in release name/body. This is not a store ship.
 # No workflow_dispatch, so a branch click cannot publish.
 # includeUpdaterJson is off so we do not upload latest.json.
 
-name: Windows tagged prerelease
+name: Windows tagged release
 
 on:
   push:
@@ -76,7 +77,7 @@ jobs:
 
             The installers are unsigned. Windows will say the publisher is unknown. That is expected. More info, then Run anyway if you trust the file.
           releaseDraft: false
-          prerelease: true
+          prerelease: false
           includeUpdaterJson: false
           releaseCommitish: ${{ github.sha }}
           args: --bundles nsis,msi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ Do not add a frontend framework. Add Tauri commands next to the existing `invoke
 
 ## Releases and CI
 
-Keep the app version and the public Git tag aligned including the beta marker (`0.1.1-beta` / `v0.1.1-beta` for this cut) in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`. Bump both together on a named cut. Do not bump the app version for a nightly alone. Do not pin a `v*` tag in README; vocawin.com names the current tagged cut and updates when that cut changes.
+Keep the app version and the public Git tag aligned as `X.Y.Z-beta` (single `-beta` marker, no `-beta.N`). For this cut that is `0.1.1-beta` / `v0.1.1-beta` in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`. Bump the numeric part and keep `-beta` on the next named cut. Do not bump the app version for a nightly alone. Do not pin a `v*` tag in README; vocawin.com names the current tagged cut and updates when that cut changes.
 
 | Workflow | Trigger | Effect |
 | --- | --- | --- |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ Do not add a frontend framework. Add Tauri commands next to the existing `invoke
 
 ## Releases and CI
 
-Keep the app version and the public Git tag aligned including the beta marker (`0.1.1-beta.1` / `v0.1.1-beta.1` for this cut) in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`. Bump both together on a named cut. Do not bump the app version for a nightly alone. Do not pin a `v*` tag in README; vocawin.com names the current tagged cut and updates when that cut changes.
+Keep the app version and the public Git tag aligned including the beta marker (`0.1.1-beta` / `v0.1.1-beta` for this cut) in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`. Bump both together on a named cut. Do not bump the app version for a nightly alone. Do not pin a `v*` tag in README; vocawin.com names the current tagged cut and updates when that cut changes.
 
 | Workflow | Trigger | Effect |
 | --- | --- | --- |
@@ -125,7 +125,7 @@ Keep the app version and the public Git tag aligned including the beta marker (`
 | `nightly.yml` | cron + dispatch | Moving `nightly` prerelease from `main` when app source changed. Not a `v*` tag. |
 | `deploy-pages.yml` | `web/**` on `main` | Publishes vocawin.com. |
 
-Named tester cuts: `v*` via `RELEASE.md` (latest prep is `v0.1.1-beta.1`). Testers use GitHub Releases, not the CI artifact. NSIS is current-user; MSI is the WiX wizard. Use one installer per PC, not both.
+Named tester cuts: `v*` via `RELEASE.md` (latest prep is `v0.1.1-beta`). Testers use GitHub Releases, not the CI artifact. NSIS is current-user; MSI is the WiX wizard. Use one installer per PC, not both.
 
 Do not set `tagName` in `windows-ci.yml`. Do not enable an updater. Do not retag. Nightly may be dispatched; a named beta must not be cut from a branch click.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ Do not add a frontend framework. Add Tauri commands next to the existing `invoke
 
 ## Releases and CI
 
-App version stays **`0.1.0`** in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` across betas. The Git tag is the public version. Do not bump the app version for a beta or a nightly. Do not pin a `v*` tag in README or on vocawin.com.
+Keep the app version and the public Git tag aligned (`0.1.1` / `v0.1.1` for this cut) in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`. Bump both together on a named cut. Do not bump the app version for a nightly alone. Do not pin a `v*` tag in README; vocawin.com names the current tagged cut and updates when that cut changes.
 
 | Workflow | Trigger | Effect |
 | --- | --- | --- |
@@ -125,13 +125,13 @@ App version stays **`0.1.0`** in `package.json`, `src-tauri/Cargo.toml`, and `sr
 | `nightly.yml` | cron + dispatch | Moving `nightly` prerelease from `main` when app source changed. Not a `v*` tag. |
 | `deploy-pages.yml` | `web/**` on `main` | Publishes vocawin.com. |
 
-Named tester cuts: `v0.1.0-beta.N` via `RELEASE.md`. Testers use GitHub Releases, not the CI artifact. NSIS is current-user; MSI is the WiX wizard. Use one installer per PC, not both.
+Named tester cuts: `v*` via `RELEASE.md` (latest prep is `v0.1.1`). Testers use GitHub Releases, not the CI artifact. NSIS is current-user; MSI is the WiX wizard. Use one installer per PC, not both.
 
 Do not set `tagName` in `windows-ci.yml`. Do not enable an updater. Do not retag. Nightly may be dispatched; a named beta must not be cut from a branch click.
 
 ## Website (`web/`)
 
-Static HTML/CSS/JS. Hero download goes to `/releases`, with a quieter nightly link. `web/tests/site.test.mjs` enforces honesty: beta, unsigned, SmartScreen, no `v*` pin, no "coming soon", no telemetry snippets, AGPL-3.0-or-later.
+Static HTML/CSS/JS. Hero download goes to `/releases`, with a quieter nightly link. Site pins name the current tagged cut. `web/tests/site.test.mjs` enforces honesty: beta, unsigned, SmartScreen, current tag pin, no "coming soon", no telemetry snippets, AGPL-3.0-or-later.
 
 If you change landing copy, run `node --test tests/site.test.mjs` from `web/`. Do not edit the VocaHQ directory repo from here.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,16 +116,16 @@ Do not add a frontend framework. Add Tauri commands next to the existing `invoke
 
 ## Releases and CI
 
-Keep the app version and the public Git tag aligned (`0.1.1` / `v0.1.1` for this cut) in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`. Bump both together on a named cut. Do not bump the app version for a nightly alone. Do not pin a `v*` tag in README; vocawin.com names the current tagged cut and updates when that cut changes.
+Keep the app version and the public Git tag aligned including the beta marker (`0.1.1-beta.1` / `v0.1.1-beta.1` for this cut) in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`. Bump both together on a named cut. Do not bump the app version for a nightly alone. Do not pin a `v*` tag in README; vocawin.com names the current tagged cut and updates when that cut changes.
 
 | Workflow | Trigger | Effect |
 | --- | --- | --- |
 | `windows-ci.yml` | `main` push, PRs, dispatch | Source-change filter. PRs: `cargo test` only. `main`/dispatch: unsigned NSIS+MSI **artifact**. Docs-only PRs skip the Windows VMs so the required check is not left pending. |
-| `windows-alpha-release.yml` | `v*` tag only | Unsigned NSIS+MSI on a **prerelease**. No `workflow_dispatch`. `includeUpdaterJson: false`. |
+| `windows-alpha-release.yml` | `v*` tag only | Unsigned NSIS+MSI on a **Latest** GitHub Release (`prerelease: false`) so it shows on the repo homepage. No `workflow_dispatch`. `includeUpdaterJson: false`. |
 | `nightly.yml` | cron + dispatch | Moving `nightly` prerelease from `main` when app source changed. Not a `v*` tag. |
 | `deploy-pages.yml` | `web/**` on `main` | Publishes vocawin.com. |
 
-Named tester cuts: `v*` via `RELEASE.md` (latest prep is `v0.1.1`). Testers use GitHub Releases, not the CI artifact. NSIS is current-user; MSI is the WiX wizard. Use one installer per PC, not both.
+Named tester cuts: `v*` via `RELEASE.md` (latest prep is `v0.1.1-beta.1`). Testers use GitHub Releases, not the CI artifact. NSIS is current-user; MSI is the WiX wizard. Use one installer per PC, not both.
 
 Do not set `tagName` in `windows-ci.yml`. Do not enable an updater. Do not retag. Nightly may be dispatched; a named beta must not be cut from a branch click.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,25 +4,25 @@ This is the checklist we already use. A `v*` tag is what ships a **named** teste
 
 ## Tag
 
-The latest tagged tester cut is `v0.1.1`. Cut the next `v*` tag only after Jatin asks. Tag the commit testers should run, then push it. That is the only trigger.
+The latest tagged tester cut is `v0.1.1-beta.1`. Cut the next `v*` tag only after Jatin asks. Tag the commit testers should run, then push it. That is the only trigger.
 
-Keep the app version and the public Git tag aligned. For this cut that means `0.1.1` in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`, public tag `v0.1.1`, and installers named `VocaWin_0.1.1_*`. Bump both together when you cut the next named release. Product status stays Beta in prose.
+Keep the app version and the public Git tag aligned, including the beta marker. For this cut that means `0.1.1-beta.1` in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`, public tag `v0.1.1-beta.1`, and installers named `VocaWin_0.1.1-beta.1_*`. Bump both together when you cut the next named release. Product status stays Beta in notes and site prose.
 
 Do not retag. Do not use workflow_dispatch. `.github/workflows/windows-alpha-release.yml` has no manual trigger on purpose, so a branch click cannot publish.
 
 ## What CI does
 
-A `v*` tag push runs `windows-alpha-release.yml`. tauri-action builds unsigned NSIS and MSI and attaches them to a GitHub Release named `VocaWin <tag> (Windows beta)`. The Release is always a prerelease. `includeUpdaterJson` stays off. There is no store signature and no auto-update.
+A `v*` tag push runs `windows-alpha-release.yml`. tauri-action builds unsigned NSIS and MSI and attaches them to a GitHub Release named `VocaWin <tag> (Windows beta)`. For named `v*` cuts the Release is published as **Latest** (`prerelease: false`) so it appears on the repo homepage. Do not check the GitHub prerelease box for these cuts. `includeUpdaterJson` stays off. There is no store signature and no auto-update.
 
 `windows-ci.yml` on main still uploads a workflow artifact. Testers should ignore that and use a GitHub Release: the latest tagged `v*` cut, or [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly) if they want today's `main`.
 
-The nightly Release is always a prerelease named `nightly`. It is deleted and recreated; the URL stays the same. The README release badge uses `sort=semver` so `nightly` does not steal it from `v*`.
+The nightly Release is a separate path and stays a prerelease named `nightly`. It is deleted and recreated; the URL stays the same. Named `v*` cuts are Latest; nightly does not replace them on the homepage.
 
-tauri-action writes a generic body about vocawin.com and SmartScreen. If you drafted real notes before the job finished, they get overwritten. Put the notes and the Ready screenshot back after the installers land.
+tauri-action writes a generic body about vocawin.com and SmartScreen. If you drafted real notes before the job finished, they get overwritten. Put the notes and the Ready screenshot back after the installers land. Keep beta language in those notes.
 
 ## Release notes
 
-Paste short, honest notes. What changed. Hold Right Alt. Audio stays on this PC. Unsigned. Windows will say the publisher is unknown. More info, then Run anyway. [vocawin.com](https://vocawin.com) points here. NSIS is current-user. MSI is the wizard. Use one. File an issue if it breaks.
+Paste short, honest notes. What changed. Hold Right Alt. Audio stays on this PC. Unsigned. Windows will say the publisher is unknown. More info, then Run anyway. [vocawin.com](https://vocawin.com) points here. NSIS is current-user. MSI is the wizard. Use one. File an issue if it breaks. Say beta in the notes.
 
 Upload a real Ready-screen shot as a release asset (alpha.2 used `vocawin-ready.png`) and embed it in the body:
 
@@ -34,15 +34,15 @@ You can rename the Release to drop the `v` and the `(Windows beta)` suffix. That
 
 ## Public pages
 
-[vocawin.com](https://vocawin.com) lives in `web/` and publishes from `main` when `web/` changes. Name the current tagged cut (`v0.1.1`) next to the download facts and in JSON-LD `softwareVersion`, and link [that tag](https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1). The primary download button can still go to [Releases](https://github.com/VocaHQ/vocawin/releases). Nightly stays on the moving [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly) tag. When we cut the next named tag, bump those pins in the same site PR and keep the app version aligned with the tag. Check the live page still says beta, unsigned, More info then Run anyway.
+[vocawin.com](https://vocawin.com) lives in `web/` and publishes from `main` when `web/` changes. Name the current tagged cut (`v0.1.1-beta.1`) next to the download facts and in JSON-LD `softwareVersion`, and link [that tag](https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1-beta.1). The primary download button can still go to [Releases](https://github.com/VocaHQ/vocawin/releases). Nightly stays on the moving [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly) tag. When we cut the next named tag, bump those pins in the same site PR and keep the app version aligned with the tag (including `-beta.N`). Check the live page still says beta, unsigned, More info then Run anyway.
 
-The README badge is `github/v/release` with `include_prereleases`. It tracks the latest prerelease by itself. Leave it pointed at `/releases`. Do not pin a tag in the README.
+The README badge is `github/v/release` with `include_prereleases`. Named `v*` cuts publish as Latest, so the homepage and badge can surface them without relying on the prerelease flag. Leave the badge pointed at `/releases`. Do not pin a tag in the README.
 
 `docs/setup.md` already points at `/releases`. Leave it that way.
 
 Glance at the GitHub repo description. It should say beta and GitHub Releases, not Coming soon.
 
-The OG source under `web/assets/og/src` still says Coming soon. That is design art, not a tag you rewrite on every cut. Leave it unless VocaDesign replaces it.
+The OG texture under `web/assets/og/src` still says Coming soon. That is design art, not a tag you rewrite on every cut. Leave it unless VocaDesign replaces it.
 
 ## VocaHQ
 
@@ -50,4 +50,4 @@ VocaHQ owns vocahq.com and the family PRODUCT.md. If that page still lists an ol
 
 ## What not to do
 
-Do not pin a `v*` tag in the README. vocawin.com should name the current tagged cut and get updated on the next tag. Do not ship a named cut where the app version and the `v*` tag disagree. Do not bump the app version for a nightly alone. Do not tell testers the build is signed, Coming soon, or Available now. Do not cut a named beta from a branch click. Nightly may be dispatched by hand.
+Do not pin a `v*` tag in the README. vocawin.com should name the current tagged cut and get updated on the next tag. Do not ship a named cut where the app version and the `v*` tag disagree, and do not drop the `-beta.N` marker from either side while the cut is still beta. Do not force the GitHub prerelease checkbox on named `v*` cuts (those publish as Latest for homepage visibility). Do not bump the app version for a nightly alone. Do not tell testers the build is signed, Coming soon, or Available now. Do not cut a named beta from a branch click. Nightly may be dispatched by hand and remains a separate prerelease path.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,9 +4,9 @@ This is the checklist we already use. A `v*` tag is what ships a **named** teste
 
 ## Tag
 
-The latest tagged tester cut is `v0.1.0-beta.1`. It is live on GitHub Releases. Cut the next `v*` tag only after Jatin asks. Tag the commit testers should run, then push it. That is the only trigger.
+The latest tagged tester cut is `v0.1.1`. Cut the next `v*` tag only after Jatin asks. Tag the commit testers should run, then push it. That is the only trigger.
 
-`package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` stay at `0.1.0` across these cuts. The installers keep the `VocaWin_0.1.0_*` filenames. The Git tag is the public version. Do not bump the app version for a beta.
+Keep the app version and the public Git tag aligned. For this cut that means `0.1.1` in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`, public tag `v0.1.1`, and installers named `VocaWin_0.1.1_*`. Bump both together when you cut the next named release. Product status stays Beta in prose.
 
 Do not retag. Do not use workflow_dispatch. `.github/workflows/windows-alpha-release.yml` has no manual trigger on purpose, so a branch click cannot publish.
 
@@ -34,7 +34,7 @@ You can rename the Release to drop the `v` and the `(Windows beta)` suffix. That
 
 ## Public pages
 
-[vocawin.com](https://vocawin.com) lives in `web/` and publishes from `main` when `web/` changes. Name the current tagged cut (`v0.1.0-beta.1`) next to the download facts and in JSON-LD `softwareVersion`, and link [that tag](https://github.com/VocaHQ/vocawin/releases/tag/v0.1.0-beta.1). The primary download button can still go to [Releases](https://github.com/VocaHQ/vocawin/releases). Nightly stays on the moving [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly) tag. When we cut the next named tag, bump those pins in the same site PR. Check the live page still says beta, unsigned, More info then Run anyway.
+[vocawin.com](https://vocawin.com) lives in `web/` and publishes from `main` when `web/` changes. Name the current tagged cut (`v0.1.1`) next to the download facts and in JSON-LD `softwareVersion`, and link [that tag](https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1). The primary download button can still go to [Releases](https://github.com/VocaHQ/vocawin/releases). Nightly stays on the moving [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly) tag. When we cut the next named tag, bump those pins in the same site PR and keep the app version aligned with the tag. Check the live page still says beta, unsigned, More info then Run anyway.
 
 The README badge is `github/v/release` with `include_prereleases`. It tracks the latest prerelease by itself. Leave it pointed at `/releases`. Do not pin a tag in the README.
 
@@ -50,4 +50,4 @@ VocaHQ owns vocahq.com and the family PRODUCT.md. If that page still lists an ol
 
 ## What not to do
 
-Do not pin a `v*` tag in the README. vocawin.com should name the current tagged cut and get updated on the next tag. Do not bump the `0.1.0` app version for a beta or a nightly. Do not tell testers the build is signed, Coming soon, or Available now. Do not cut a named beta from a branch click. Nightly may be dispatched by hand.
+Do not pin a `v*` tag in the README. vocawin.com should name the current tagged cut and get updated on the next tag. Do not ship a named cut where the app version and the `v*` tag disagree. Do not bump the app version for a nightly alone. Do not tell testers the build is signed, Coming soon, or Available now. Do not cut a named beta from a branch click. Nightly may be dispatched by hand.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@ This is the checklist we already use. A `v*` tag is what ships a **named** teste
 
 The latest tagged tester cut is `v0.1.1-beta`. Cut the next `v*` tag only after Jatin asks. Tag the commit testers should run, then push it. That is the only trigger.
 
-Keep the app version and the public Git tag aligned, including the beta marker. For this cut that means `0.1.1-beta` in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`, public tag `v0.1.1-beta`, and installers named `VocaWin_0.1.1-beta_*`. Bump both together when you cut the next named release. Product status stays Beta in notes and site prose.
+Keep the app version and the public Git tag aligned as `X.Y.Z-beta` (a single `-beta` marker; do not use `-beta.N`). For this cut that means `0.1.1-beta` in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`, public tag `v0.1.1-beta`, and installers named `VocaWin_0.1.1-beta_*`. The next named cut bumps the numeric part and keeps `-beta` (for example `0.1.2-beta` / `v0.1.2-beta`, or `0.2.0-beta` / `v0.2.0-beta`). Product status stays Beta in notes and site prose.
 
 Do not retag. Do not use workflow_dispatch. `.github/workflows/windows-alpha-release.yml` has no manual trigger on purpose, so a branch click cannot publish.
 
@@ -50,4 +50,4 @@ VocaHQ owns vocahq.com and the family PRODUCT.md. If that page still lists an ol
 
 ## What not to do
 
-Do not pin a `v*` tag in the README. vocawin.com should name the current tagged cut and get updated on the next tag. Do not ship a named cut where the app version and the `v*` tag disagree, and do not drop the `-beta` marker from either side while the cut is still beta. Do not use a numbered suffix like `-beta.1`; next cuts bump the numeric version and keep one `-beta`. Do not force the GitHub prerelease checkbox on named `v*` cuts (those publish as Latest for homepage visibility). Do not bump the app version for a nightly alone. Do not tell testers the build is signed, Coming soon, or Available now. Do not cut a named beta from a branch click. Nightly may be dispatched by hand and remains a separate prerelease path.
+Do not pin a `v*` tag in the README. vocawin.com should name the current tagged cut and get updated on the next tag. Do not ship a named cut where the app version and the `v*` tag disagree, and do not drop the `-beta` marker from either side while the cut is still beta. Do not use `-beta.N` (no numbered beta suffix); next cuts bump `X.Y.Z` and keep one `-beta`. Do not force the GitHub prerelease checkbox on named `v*` cuts (those publish as Latest for homepage visibility). Do not bump the app version for a nightly alone. Do not tell testers the build is signed, Coming soon, or Available now. Do not cut a named beta from a branch click. Nightly may be dispatched by hand and remains a separate prerelease path.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,9 +4,9 @@ This is the checklist we already use. A `v*` tag is what ships a **named** teste
 
 ## Tag
 
-The latest tagged tester cut is `v0.1.1-beta.1`. Cut the next `v*` tag only after Jatin asks. Tag the commit testers should run, then push it. That is the only trigger.
+The latest tagged tester cut is `v0.1.1-beta`. Cut the next `v*` tag only after Jatin asks. Tag the commit testers should run, then push it. That is the only trigger.
 
-Keep the app version and the public Git tag aligned, including the beta marker. For this cut that means `0.1.1-beta.1` in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`, public tag `v0.1.1-beta.1`, and installers named `VocaWin_0.1.1-beta.1_*`. Bump both together when you cut the next named release. Product status stays Beta in notes and site prose.
+Keep the app version and the public Git tag aligned, including the beta marker. For this cut that means `0.1.1-beta` in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`, public tag `v0.1.1-beta`, and installers named `VocaWin_0.1.1-beta_*`. Bump both together when you cut the next named release. Product status stays Beta in notes and site prose.
 
 Do not retag. Do not use workflow_dispatch. `.github/workflows/windows-alpha-release.yml` has no manual trigger on purpose, so a branch click cannot publish.
 
@@ -34,7 +34,7 @@ You can rename the Release to drop the `v` and the `(Windows beta)` suffix. That
 
 ## Public pages
 
-[vocawin.com](https://vocawin.com) lives in `web/` and publishes from `main` when `web/` changes. Name the current tagged cut (`v0.1.1-beta.1`) next to the download facts and in JSON-LD `softwareVersion`, and link [that tag](https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1-beta.1). The primary download button can still go to [Releases](https://github.com/VocaHQ/vocawin/releases). Nightly stays on the moving [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly) tag. When we cut the next named tag, bump those pins in the same site PR and keep the app version aligned with the tag (including `-beta.N`). Check the live page still says beta, unsigned, More info then Run anyway.
+[vocawin.com](https://vocawin.com) lives in `web/` and publishes from `main` when `web/` changes. Name the current tagged cut (`v0.1.1-beta`) next to the download facts and in JSON-LD `softwareVersion`, and link [that tag](https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1-beta). The primary download button can still go to [Releases](https://github.com/VocaHQ/vocawin/releases). Nightly stays on the moving [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly) tag. When we cut the next named tag, bump those pins in the same site PR and keep the app version aligned with the tag (including the single `-beta` marker). Check the live page still says beta, unsigned, More info then Run anyway.
 
 The README badge is `github/v/release` with `include_prereleases`. Named `v*` cuts publish as Latest, so the homepage and badge can surface them without relying on the prerelease flag. Leave the badge pointed at `/releases`. Do not pin a tag in the README.
 
@@ -50,4 +50,4 @@ VocaHQ owns vocahq.com and the family PRODUCT.md. If that page still lists an ol
 
 ## What not to do
 
-Do not pin a `v*` tag in the README. vocawin.com should name the current tagged cut and get updated on the next tag. Do not ship a named cut where the app version and the `v*` tag disagree, and do not drop the `-beta.N` marker from either side while the cut is still beta. Do not force the GitHub prerelease checkbox on named `v*` cuts (those publish as Latest for homepage visibility). Do not bump the app version for a nightly alone. Do not tell testers the build is signed, Coming soon, or Available now. Do not cut a named beta from a branch click. Nightly may be dispatched by hand and remains a separate prerelease path.
+Do not pin a `v*` tag in the README. vocawin.com should name the current tagged cut and get updated on the next tag. Do not ship a named cut where the app version and the `v*` tag disagree, and do not drop the `-beta` marker from either side while the cut is still beta. Do not use a numbered suffix like `-beta.1`; next cuts bump the numeric version and keep one `-beta`. Do not force the GitHub prerelease checkbox on named `v*` cuts (those publish as Latest for homepage visibility). Do not bump the app version for a nightly alone. Do not tell testers the build is signed, Coming soon, or Available now. Do not cut a named beta from a branch click. Nightly may be dispatched by hand and remains a separate prerelease path.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vocawin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vocawin",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@tauri-apps/api": "^2.2.0"
       },
@@ -466,9 +466,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -570,9 +567,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -587,9 +581,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -604,9 +595,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -621,9 +609,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -638,9 +623,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -655,9 +637,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -672,9 +651,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -689,9 +665,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -706,9 +679,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -723,9 +693,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -740,9 +707,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -757,9 +721,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -774,9 +735,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -966,9 +924,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -986,9 +941,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1006,9 +958,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1026,9 +975,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1046,9 +992,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vocawin",
-  "version": "0.1.1-beta.1",
+  "version": "0.1.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vocawin",
-      "version": "0.1.1-beta.1",
+      "version": "0.1.1-beta",
       "dependencies": {
         "@tauri-apps/api": "^2.2.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vocawin",
-  "version": "0.1.1",
+  "version": "0.1.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vocawin",
-      "version": "0.1.1",
+      "version": "0.1.1-beta.1",
       "dependencies": {
         "@tauri-apps/api": "^2.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vocawin",
-  "version": "0.1.1",
+  "version": "0.1.1-beta.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vocawin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vocawin",
-  "version": "0.1.1-beta.1",
+  "version": "0.1.1-beta",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5175,7 +5175,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vocawin"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cpal",
  "flate2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5175,7 +5175,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vocawin"
-version = "0.1.1-beta.1"
+version = "0.1.1-beta"
 dependencies = [
  "cpal",
  "flate2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5175,7 +5175,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vocawin"
-version = "0.1.1"
+version = "0.1.1-beta.1"
 dependencies = [
  "cpal",
  "flate2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vocawin"
-version = "0.1.1"
+version = "0.1.1-beta.1"
 description = "Private, offline voice dictation for Windows"
 authors = ["VocaHQ"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vocawin"
-version = "0.1.0"
+version = "0.1.1"
 description = "Private, offline voice dictation for Windows"
 authors = ["VocaHQ"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vocawin"
-version = "0.1.1-beta.1"
+version = "0.1.1-beta"
 description = "Private, offline voice dictation for Windows"
 authors = ["VocaHQ"]
 edition = "2021"

--- a/src-tauri/src/machine.rs
+++ b/src-tauri/src/machine.rs
@@ -374,7 +374,7 @@ mod tests {
     fn report_lists_version_os_cpu_ram_gpu_and_debug_flag() {
         let report = debug_report(sample_gpu(), false, "[warn] hotkey busy\n[error] boom");
         assert!(
-            report.text.starts_with("VocaWin 0.1.0\n"),
+            report.text.starts_with(&format!("VocaWin {APP_VERSION}\n")),
             "{}",
             report.text
         );
@@ -392,7 +392,7 @@ mod tests {
         assert!(report.text.contains("Debug logging: off"));
         assert!(report.text.contains("[warn] hotkey busy"));
         assert!(report.text.contains("[error] boom"));
-        assert_eq!(report.version, "0.1.0");
+        assert_eq!(report.version, APP_VERSION);
         assert!(!report.debug_logging);
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VocaWin",
-  "version": "0.1.1-beta.1",
+  "version": "0.1.1-beta",
   "identifier": "com.vocahq.vocawin",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VocaWin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.vocahq.vocawin",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "VocaWin",
-  "version": "0.1.1",
+  "version": "0.1.1-beta.1",
   "identifier": "com.vocahq.vocawin",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/web/index.html
+++ b/web/index.html
@@ -56,8 +56,8 @@
         "applicationCategory": "UtilitiesApplication",
         "operatingSystem": "Windows 10, Windows 11",
         "url": "https://vocawin.com/",
-        "downloadUrl": "https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1-beta.1",
-        "softwareVersion": "v0.1.1-beta.1",
+        "downloadUrl": "https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1-beta",
+        "softwareVersion": "v0.1.1-beta",
         "isAccessibleForFree": true,
         "offers": {
           "@type": "Offer",
@@ -200,7 +200,7 @@
           <p class="hero-note">
             Beta. Unsigned. Windows will likely say the publisher is
             unknown. More info, then Run anyway. Latest tagged build is
-            <a href="https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1-beta.1">v0.1.1-beta.1</a>.
+            <a href="https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1-beta">v0.1.1-beta</a>.
           </p>
           <ul class="hero-proof">
             <li>
@@ -531,7 +531,7 @@
             <h3>Download the beta</h3>
             <ul class="install-facts">
               <li><b>Status</b><span>Beta. Unsigned.</span></li>
-              <li><b>Tagged</b><span><a href="https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1-beta.1">v0.1.1-beta.1</a></span></li>
+              <li><b>Tagged</b><span><a href="https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1-beta">v0.1.1-beta</a></span></li>
               <li><b>Files</b><span>NSIS current-user setup.exe and MSI</span></li>
               <li><b>Needs</b><span>Windows 10 version 1809+ or Windows 11</span></li>
               <li><b>License</b><span>AGPL-3.0-or-later</span></li>

--- a/web/index.html
+++ b/web/index.html
@@ -56,8 +56,8 @@
         "applicationCategory": "UtilitiesApplication",
         "operatingSystem": "Windows 10, Windows 11",
         "url": "https://vocawin.com/",
-        "downloadUrl": "https://github.com/VocaHQ/vocawin/releases/tag/v0.1.0-beta.1",
-        "softwareVersion": "v0.1.0-beta.1",
+        "downloadUrl": "https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1",
+        "softwareVersion": "v0.1.1",
         "isAccessibleForFree": true,
         "offers": {
           "@type": "Offer",
@@ -200,7 +200,7 @@
           <p class="hero-note">
             Beta. Unsigned. Windows will likely say the publisher is
             unknown. More info, then Run anyway. Latest tagged build is
-            <a href="https://github.com/VocaHQ/vocawin/releases/tag/v0.1.0-beta.1">v0.1.0-beta.1</a>.
+            <a href="https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1">v0.1.1</a>.
           </p>
           <ul class="hero-proof">
             <li>
@@ -531,7 +531,7 @@
             <h3>Download the beta</h3>
             <ul class="install-facts">
               <li><b>Status</b><span>Beta. Unsigned.</span></li>
-              <li><b>Tagged</b><span><a href="https://github.com/VocaHQ/vocawin/releases/tag/v0.1.0-beta.1">v0.1.0-beta.1</a></span></li>
+              <li><b>Tagged</b><span><a href="https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1">v0.1.1</a></span></li>
               <li><b>Files</b><span>NSIS current-user setup.exe and MSI</span></li>
               <li><b>Needs</b><span>Windows 10 version 1809+ or Windows 11</span></li>
               <li><b>License</b><span>AGPL-3.0-or-later</span></li>

--- a/web/index.html
+++ b/web/index.html
@@ -56,8 +56,8 @@
         "applicationCategory": "UtilitiesApplication",
         "operatingSystem": "Windows 10, Windows 11",
         "url": "https://vocawin.com/",
-        "downloadUrl": "https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1",
-        "softwareVersion": "v0.1.1",
+        "downloadUrl": "https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1-beta.1",
+        "softwareVersion": "v0.1.1-beta.1",
         "isAccessibleForFree": true,
         "offers": {
           "@type": "Offer",
@@ -200,7 +200,7 @@
           <p class="hero-note">
             Beta. Unsigned. Windows will likely say the publisher is
             unknown. More info, then Run anyway. Latest tagged build is
-            <a href="https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1">v0.1.1</a>.
+            <a href="https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1-beta.1">v0.1.1-beta.1</a>.
           </p>
           <ul class="hero-proof">
             <li>
@@ -531,7 +531,7 @@
             <h3>Download the beta</h3>
             <ul class="install-facts">
               <li><b>Status</b><span>Beta. Unsigned.</span></li>
-              <li><b>Tagged</b><span><a href="https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1">v0.1.1</a></span></li>
+              <li><b>Tagged</b><span><a href="https://github.com/VocaHQ/vocawin/releases/tag/v0.1.1-beta.1">v0.1.1-beta.1</a></span></li>
               <li><b>Files</b><span>NSIS current-user setup.exe and MSI</span></li>
               <li><b>Needs</b><span>Windows 10 version 1809+ or Windows 11</span></li>
               <li><b>License</b><span>AGPL-3.0-or-later</span></li>

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -42,10 +42,10 @@ test("unsigned beta download is explicit and not oversold", () => {
   );
   assert.match(
     html,
-    /href="https:\/\/github\.com\/VocaHQ\/vocawin\/releases\/tag\/v0\.1\.1"/,
+    /href="https:\/\/github\.com\/VocaHQ\/vocawin\/releases\/tag\/v0\.1\.1-beta\.1"/,
   );
-  assert.match(html, /"softwareVersion": "v0\.1\.1"/);
-  assert.match(html, /v0\.1\.1/);
+  assert.match(html, /"softwareVersion": "v0\.1\.1-beta\.1"/);
+  assert.match(html, /v0\.1\.1-beta\.1/);
   assert.doesNotMatch(html, /v0\.1\.0-alpha/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocawin\/issues"/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocawin\/blob\/main\/docs\/setup\.md"/);

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -42,10 +42,10 @@ test("unsigned beta download is explicit and not oversold", () => {
   );
   assert.match(
     html,
-    /href="https:\/\/github\.com\/VocaHQ\/vocawin\/releases\/tag\/v0\.1\.0-beta\.1"/,
+    /href="https:\/\/github\.com\/VocaHQ\/vocawin\/releases\/tag\/v0\.1\.1"/,
   );
-  assert.match(html, /"softwareVersion": "v0\.1\.0-beta\.1"/);
-  assert.match(html, /v0\.1\.0-beta\.1/);
+  assert.match(html, /"softwareVersion": "v0\.1\.1"/);
+  assert.match(html, /v0\.1\.1/);
   assert.doesNotMatch(html, /v0\.1\.0-alpha/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocawin\/issues"/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocawin\/blob\/main\/docs\/setup\.md"/);

--- a/web/tests/site.test.mjs
+++ b/web/tests/site.test.mjs
@@ -42,10 +42,10 @@ test("unsigned beta download is explicit and not oversold", () => {
   );
   assert.match(
     html,
-    /href="https:\/\/github\.com\/VocaHQ\/vocawin\/releases\/tag\/v0\.1\.1-beta\.1"/,
+    /href="https:\/\/github\.com\/VocaHQ\/vocawin\/releases\/tag\/v0\.1\.1-beta"/,
   );
-  assert.match(html, /"softwareVersion": "v0\.1\.1-beta\.1"/);
-  assert.match(html, /v0\.1\.1-beta\.1/);
+  assert.match(html, /"softwareVersion": "v0\.1\.1-beta"/);
+  assert.match(html, /v0\.1\.1-beta/);
   assert.doesNotMatch(html, /v0\.1\.0-alpha/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocawin\/issues"/);
   assert.match(html, /href="https:\/\/github\.com\/VocaHQ\/vocawin\/blob\/main\/docs\/setup\.md"/);


### PR DESCRIPTION
## Summary

Keeps app version and public tag aligned on a single `-beta` marker, and publishes the named GitHub Release as Latest so it shows on the repo homepage.

- App version `0.1.1-beta` in package.json, src-tauri/Cargo.toml, src-tauri/tauri.conf.json (installers will be `VocaWin_0.1.1-beta_*`)
- Site pins and tests: every pin is `v0.1.1-beta` (not plain `v0.1.1`, not `v0.1.1-beta.1`)
- Debug report version reads `CARGO_PKG_VERSION` instead of a hardcoded string
- RELEASE.md / AGENTS.md: app+tag match as `X.Y.Z-beta`; no `-beta.N`; next cut bumps the numeric part and keeps `-beta`; named `v*` GitHub Releases use `prerelease: false` (Latest); nightly stays a separate prerelease path; beta stays in notes/site prose
- windows-alpha-release.yml: `prerelease: false`; comments/name no longer say Always prerelease for tagged `v*` cuts; tag-only trigger and unsigned story unchanged
- Lockfiles refreshed for the version bump only

After merge, cut and push tag `v0.1.1-beta` (not in this PR). The tag workflow owns the GitHub Release as Latest.

VocaHQ should update family pages / PRODUCT.md for the new Windows tag. This PR does not touch the HQ repo.

## Test plan

- [x] `node --test web/tests/site.test.mjs` (18/18 pass)
- [ ] Confirm no leftover plain `v0.1.1` or `-beta.1` pins on the landing page
- [ ] After merge: push `v0.1.1-beta`, wait for unsigned NSIS/MSI on a Latest release, then paste release notes + Ready shot

## Known limits

Site links target `v0.1.1-beta` before the tag exists. That is intentional for this prep PR; the tag is post-merge only.
