### PR TITLE
fix: ship NSIS only while the version keeps -beta

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -127,14 +127,14 @@ jobs:
       - name: Test Rust command layer
         run: cargo test --manifest-path src-tauri/Cargo.toml
 
-      - name: Build NSIS and MSI
+      - name: Build NSIS
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_TARGET_DIR: C:\t
           CMAKE_GENERATOR: Ninja
         with:
-          args: --bundles nsis,msi
+          args: --bundles nsis
           includeUpdaterJson: false
 
       - name: Stage nightly installers
@@ -145,15 +145,12 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           $nsis = Get-ChildItem "C:\t\release\bundle\nsis\*-setup.exe" | Select-Object -First 1
-          $msi = Get-ChildItem "C:\t\release\bundle\msi\*.msi" | Select-Object -First 1
-          if (-not $nsis -or -not $msi) {
-            throw "Missing NSIS or MSI under C:\t\release\bundle"
+          if (-not $nsis) {
+            throw "Missing NSIS under C:\t\release\bundle\nsis"
           }
           New-Item -ItemType Directory -Force nightly-out | Out-Null
           Copy-Item $nsis.FullName "nightly-out\VocaWin-nightly-$env:NIGHTLY_DATE-$env:SHORT_SHA-x64-setup.exe"
-          Copy-Item $msi.FullName "nightly-out\VocaWin-nightly-$env:NIGHTLY_DATE-$env:SHORT_SHA-x64.msi"
           Copy-Item $nsis.FullName "nightly-out\VocaWin-nightly-x64-setup.exe"
-          Copy-Item $msi.FullName "nightly-out\VocaWin-nightly-x64.msi"
           Get-FileHash "nightly-out\*" -Algorithm SHA256 |
             ForEach-Object { "{0}  {1}" -f $_.Hash.ToLowerInvariant(), (Split-Path $_.Path -Leaf) } |
             Set-Content -Encoding ascii nightly-out\checksums.txt
@@ -183,9 +180,8 @@ jobs:
             "## Install",
             "",
             "- ``VocaWin-nightly-x64-setup.exe`` — NSIS, current-user",
-            "- ``VocaWin-nightly-x64.msi`` — WiX wizard",
             "",
-            "Use one, not both, on the same PC. Read the [setup guide](https://github.com/VocaHQ/vocawin/blob/main/docs/setup.md) first.",
+            "Install the NSIS setup, then read the [setup guide](https://github.com/VocaHQ/vocawin/blob/main/docs/setup.md) first.",
             "",
             "## Build",
             "",
@@ -215,8 +211,6 @@ jobs:
             --target $sha `
             --repo $repo `
             nightly-out/VocaWin-nightly-x64-setup.exe `
-            nightly-out/VocaWin-nightly-x64.msi `
             nightly-out/VocaWin-nightly-$($env:NIGHTLY_DATE)-$($env:SHORT_SHA)-x64-setup.exe `
-            nightly-out/VocaWin-nightly-$($env:NIGHTLY_DATE)-$($env:SHORT_SHA)-x64.msi `
             nightly-out/checksums.txt
           if ($LASTEXITCODE -ne 0) { throw "gh release create failed" }

--- a/.github/workflows/windows-alpha-release.yml
+++ b/.github/workflows/windows-alpha-release.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
       - name: Install frontend dependencies
         run: npm ci
-      - name: Build NSIS and MSI, attach to the tag Release
+      - name: Build NSIS, attach to the tag Release
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -80,4 +80,4 @@ jobs:
           prerelease: false
           includeUpdaterJson: false
           releaseCommitish: ${{ github.sha }}
-          args: --bundles nsis,msi
+          args: --bundles nsis

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -141,7 +141,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
       - name: Install frontend dependencies
         run: npm ci
-      - name: Build NSIS and MSI installers
+      - name: Build NSIS installer
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -151,11 +151,10 @@ jobs:
           # Build only. Do not set tagName. Tagged beta Releases live in
           # windows-alpha-release.yml. The moving nightly Release lives in
           # nightly.yml. This job stays artifact-only.
-          args: --bundles nsis,msi
+          args: --bundles nsis
           includeUpdaterJson: false
       # tauri-action with CARGO_TARGET_DIR=C:\t writes:
       #   C:\t\release\bundle\nsis\VocaWin_*_x64-setup.exe
-      #   C:\t\release\bundle\msi\VocaWin_*_x64_en-US.msi
       # Confirmed on the 2026-08-18 installer job (run 32196306136).
       # Installers stay unsigned. Self-sign hung on Authenticode timestamps.
       - name: Upload Windows beta installers
@@ -164,6 +163,5 @@ jobs:
           name: VocaWin-windows-beta
           path: |
             C:/t/release/bundle/nsis/*-setup.exe
-            C:/t/release/bundle/msi/*.msi
           if-no-files-found: error
           retention-days: 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Prereqs: Node 20+ (CI uses 22), Rust stable, and [Tauri Windows prerequisites](h
 | `npm run build` | `tsc --noEmit && vite build` |
 | `npm run tauri` | Tauri CLI passthrough |
 | `npm run tauri dev` | Desktop development |
-| `npm run tauri build` | NSIS `.exe` on Windows (MSI paused for X.Y.Z-beta) |
+| `npm run tauri build` | NSIS `.exe` on Windows (`bundle.targets` is nsis-only while version is X.Y.Z-beta) |
 | `npm run check` | Frontend build + `cargo test --manifest-path src-tauri/Cargo.toml` |
 | `cargo test --manifest-path src-tauri/Cargo.toml` | Rust unit tests (Linux/macOS OK) |
 
@@ -125,7 +125,7 @@ Keep the app version and the public Git tag aligned as `X.Y.Z-beta` (single `-be
 | `nightly.yml` | cron + dispatch | Moving `nightly` prerelease from `main` when app source changed. Not a `v*` tag. |
 | `deploy-pages.yml` | `web/**` on `main` | Publishes vocawin.com. |
 
-Named tester cuts: `v*` via `RELEASE.md` (latest prep is `v0.1.1-beta`). Testers use GitHub Releases, not the CI artifact. While the app version is X.Y.Z-beta, the tagged cut is NSIS only (current-user). MSI returns when a cut uses a numeric-only version.
+Named tester cuts: `v*` via `RELEASE.md` (latest prep is `v0.1.1-beta`). Testers use GitHub Releases, not the CI artifact. While the app version is X.Y.Z-beta, the tagged cut is NSIS only (current-user): `bundle.targets` is `nsis` and workflows use `--bundles nsis`. To restore MSI on a numeric-only version, add `msi` to both places in the same PR (keep the `wix` block). No automatic switch.
 
 Do not set `tagName` in `windows-ci.yml`. Do not enable an updater. Do not retag. Nightly may be dispatched; a named beta must not be cut from a branch click.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Rules:
 
 | Layer | Location | Notes |
 | --- | --- | --- |
-| Tauri 2 shell | `src-tauri/` | Identifier `com.vocahq.vocawin`. Bundles NSIS + MSI. |
+| Tauri 2 shell | `src-tauri/` | Identifier `com.vocahq.vocawin`. Bundles NSIS (MSI paused while version is X.Y.Z-beta). |
 | TypeScript UI | `src/` | Vanilla TS. `src/main.ts` + `src/style.css`. No React. Vite on port **1420**. |
 | Rust | `src-tauri/src/` | Crate `vocawin_lib`. Commands, tray, capture, STT, inject. |
 | Landing page | `web/` | Static vocawin.com. No build step. GitHub Pages. |
@@ -66,7 +66,7 @@ Prereqs: Node 20+ (CI uses 22), Rust stable, and [Tauri Windows prerequisites](h
 | `npm run build` | `tsc --noEmit && vite build` |
 | `npm run tauri` | Tauri CLI passthrough |
 | `npm run tauri dev` | Desktop development |
-| `npm run tauri build` | NSIS `.exe` + MSI on Windows |
+| `npm run tauri build` | NSIS `.exe` on Windows (MSI paused for X.Y.Z-beta) |
 | `npm run check` | Frontend build + `cargo test --manifest-path src-tauri/Cargo.toml` |
 | `cargo test --manifest-path src-tauri/Cargo.toml` | Rust unit tests (Linux/macOS OK) |
 
@@ -107,7 +107,7 @@ Do not add a frontend framework. Add Tauri commands next to the existing `invoke
 
 ## Windows pitfalls (verified)
 
-- **Unsigned / SmartScreen** — NSIS and MSI have no purchased CA. Windows will say the publisher is unknown. That is expected. Do not claim a Store listing or a signed stable.
+- **Unsigned / SmartScreen** — NSIS has no purchased CA. Windows will say the publisher is unknown. That is expected. Do not claim a Store listing or a signed stable.
 - **Elevated windows** — UIPI can block clipboard/`SendInput` injection into admin targets. Documented in README and `web/`; do not promise it works there.
 - **GPU** — Vulkan (whisper.cpp) and DirectML (ONNX) with CPU fallback. Catalog labels must follow `cfg(vocawin_whisper_vulkan)`.
 - **Hotkeys** — `RegisterHotKey` cannot bind a lone modifier; the LL hook does. AltGr (Ctrl+Right Alt) must not be consumed. Default is Right Alt (`AltRight`).
@@ -120,12 +120,12 @@ Keep the app version and the public Git tag aligned as `X.Y.Z-beta` (single `-be
 
 | Workflow | Trigger | Effect |
 | --- | --- | --- |
-| `windows-ci.yml` | `main` push, PRs, dispatch | Source-change filter. PRs: `cargo test` only. `main`/dispatch: unsigned NSIS+MSI **artifact**. Docs-only PRs skip the Windows VMs so the required check is not left pending. |
-| `windows-alpha-release.yml` | `v*` tag only | Unsigned NSIS+MSI on a **Latest** GitHub Release (`prerelease: false`) so it shows on the repo homepage. No `workflow_dispatch`. `includeUpdaterJson: false`. |
+| `windows-ci.yml` | `main` push, PRs, dispatch | Source-change filter. PRs: `cargo test` only. `main`/dispatch: unsigned NSIS **artifact**. Docs-only PRs skip the Windows VMs so the required check is not left pending. |
+| `windows-alpha-release.yml` | `v*` tag only | Unsigned NSIS on a **Latest** GitHub Release (`prerelease: false`) so it shows on the repo homepage. X.Y.Z-beta cuts are NSIS-only (MSI rejects `-beta`). No `workflow_dispatch`. `includeUpdaterJson: false`. |
 | `nightly.yml` | cron + dispatch | Moving `nightly` prerelease from `main` when app source changed. Not a `v*` tag. |
 | `deploy-pages.yml` | `web/**` on `main` | Publishes vocawin.com. |
 
-Named tester cuts: `v*` via `RELEASE.md` (latest prep is `v0.1.1-beta`). Testers use GitHub Releases, not the CI artifact. NSIS is current-user; MSI is the WiX wizard. Use one installer per PC, not both.
+Named tester cuts: `v*` via `RELEASE.md` (latest prep is `v0.1.1-beta`). Testers use GitHub Releases, not the CI artifact. While the app version is X.Y.Z-beta, the tagged cut is NSIS only (current-user). MSI returns when a cut uses a numeric-only version.
 
 Do not set `tagName` in `windows-ci.yml`. Do not enable an updater. Do not retag. Nightly may be dispatched; a named beta must not be cut from a branch click.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,7 +12,9 @@ Do not retag. Do not use workflow_dispatch. `.github/workflows/windows-alpha-rel
 
 ## What CI does
 
-A `v*` tag push runs `windows-alpha-release.yml`. tauri-action builds unsigned NSIS and MSI and attaches them to a GitHub Release named `VocaWin <tag> (Windows beta)`. For named `v*` cuts the Release is published as **Latest** (`prerelease: false`) so it appears on the repo homepage. Do not check the GitHub prerelease box for these cuts. `includeUpdaterJson` stays off. There is no store signature and no auto-update.
+A `v*` tag push runs `windows-alpha-release.yml`. tauri-action builds an unsigned NSIS installer and attaches it to a GitHub Release named `VocaWin <tag> (Windows beta)`. For named `v*` cuts the Release is published as **Latest** (`prerelease: false`) so it appears on the repo homepage. Do not check the GitHub prerelease box for these cuts. `includeUpdaterJson` stays off. There is no store signature and no auto-update.
+
+Named `X.Y.Z-beta` cuts ship **NSIS only**. WiX/MSI rejects non-numeric prerelease identifiers like `-beta`, so MSI is not part of tagged beta cuts (or nightly/CI installer jobs) while the app version keeps that marker. MSI can return when a cut uses a numeric-only version.
 
 `windows-ci.yml` on main still uploads a workflow artifact. Testers should ignore that and use a GitHub Release: the latest tagged `v*` cut, or [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly) if they want today's `main`.
 
@@ -22,7 +24,7 @@ tauri-action writes a generic body about vocawin.com and SmartScreen. If you dra
 
 ## Release notes
 
-Paste short, honest notes. What changed. Hold Right Alt. Audio stays on this PC. Unsigned. Windows will say the publisher is unknown. More info, then Run anyway. [vocawin.com](https://vocawin.com) points here. NSIS is current-user. MSI is the wizard. Use one. File an issue if it breaks. Say beta in the notes.
+Paste short, honest notes. What changed. Hold Right Alt. Audio stays on this PC. Unsigned. Windows will say the publisher is unknown. More info, then Run anyway. [vocawin.com](https://vocawin.com) points here. NSIS is current-user. MSI is paused for X.Y.Z-beta cuts. File an issue if it breaks. Say beta in the notes.
 
 Upload a real Ready-screen shot as a release asset (alpha.2 used `vocawin-ready.png`) and embed it in the body:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,7 @@ Do not retag. Do not use workflow_dispatch. `.github/workflows/windows-alpha-rel
 
 A `v*` tag push runs `windows-alpha-release.yml`. tauri-action builds an unsigned NSIS installer and attaches it to a GitHub Release named `VocaWin <tag> (Windows beta)`. For named `v*` cuts the Release is published as **Latest** (`prerelease: false`) so it appears on the repo homepage. Do not check the GitHub prerelease box for these cuts. `includeUpdaterJson` stays off. There is no store signature and no auto-update.
 
-Named `X.Y.Z-beta` cuts ship **NSIS only**. WiX/MSI rejects non-numeric prerelease identifiers like `-beta`, so MSI is not part of tagged beta cuts (or nightly/CI installer jobs) while the app version keeps that marker. MSI can return when a cut uses a numeric-only version.
+Named `X.Y.Z-beta` cuts ship **NSIS only**. WiX/MSI rejects non-numeric prerelease identifiers like `-beta`, so MSI is not part of tagged beta cuts (or nightly/CI installer jobs) while the app version keeps that marker. `bundle.targets` in `src-tauri/tauri.conf.json` is `nsis` only (the `wix` config block stays for later). Workflows pin `--bundles nsis` the same way. Restoring MSI is intentional and manual: on a numeric-only version, add `msi` to `bundle.targets` and to every workflow `--bundles` flag in the same PR. Do not invent automatic version switching.
 
 `windows-ci.yml` on main still uploads a workflow artifact. Testers should ignore that and use a GitHub Release: the latest tagged `v*` cut, or [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly) if they want today's `main`.
 
@@ -24,7 +24,7 @@ tauri-action writes a generic body about vocawin.com and SmartScreen. If you dra
 
 ## Release notes
 
-Paste short, honest notes. What changed. Hold Right Alt. Audio stays on this PC. Unsigned. Windows will say the publisher is unknown. More info, then Run anyway. [vocawin.com](https://vocawin.com) points here. NSIS is current-user. MSI is paused for X.Y.Z-beta cuts. File an issue if it breaks. Say beta in the notes.
+Paste short, honest notes. What changed. Hold Right Alt. Audio stays on this PC. Unsigned. Windows will say the publisher is unknown. More info, then Run anyway. [vocawin.com](https://vocawin.com) points here. NSIS is current-user. MSI is paused for X.Y.Z-beta cuts; bring it back only with a numeric-only version by editing `bundle.targets` and workflow `--bundles` together. File an issue if it breaks. Say beta in the notes.
 
 Upload a real Ready-screen shot as a release asset (alpha.2 used `vocawin-ready.png`) and embed it in the body:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -2,11 +2,11 @@
 
 This is the tester page for the VocaWin beta. [vocawin.com](https://vocawin.com) points testers at [GitHub Releases](https://github.com/VocaHQ/vocawin/releases). There is no Voca account and no hosted speech API.
 
-The latest tagged Release is the last cut we named. If you want today's `main`, use the [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly). Same unsigned NSIS and MSI. Say it is a nightly and include the commit from that Release if you file an issue.
+The latest tagged Release is the last cut we named. If you want today's `main`, use the [nightly](https://github.com/VocaHQ/vocawin/releases/tag/nightly). Same unsigned NSIS (MSI paused while the app version is X.Y.Z-beta). Say it is a nightly and include the commit from that Release if you file an issue.
 
-The NSIS and MSI are unsigned. That is not a store signature. Windows will likely say the publisher is unknown. That is SmartScreen. Use More info, then Run anyway, only if you trust the GitHub Release you downloaded.
+The NSIS installer is unsigned. That is not a store signature. Windows will likely say the publisher is unknown. That is SmartScreen. Use More info, then Run anyway, only if you trust the GitHub Release you downloaded.
 
-There are two installers. The NSIS `.exe` is a current-user setup. The MSI is the WiX wizard. Use one, not both, on the same PC.
+The tagged cut ships an NSIS `.exe` (current-user). MSI is paused while the version keeps a `-beta` marker, because WiX rejects non-numeric prerelease ids.
 
 The first run asks you to download a speech-to-text model. That uses the network once. After that, audio stays on this PC.
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,7 @@
   "bundle": {
     "active": true,
     "icon": ["icons/icon.png", "icons/icon.ico", "icons/installer/setup-icon-256.png"],
-    "targets": ["nsis", "msi"],
+    "targets": ["nsis"],
     "homepage": "https://github.com/VocaHQ/vocawin/blob/main/docs/setup.md",
     "windows": {
       "nsis": {


### PR DESCRIPTION
## Summary
- Tagged v0.1.1-beta release failed after NSIS built: MSI cannot take a -beta prerelease id.
- Named cuts, CI installer artifacts, and nightly now build NSIS only while the app version is X.Y.Z-beta.
- RELEASE.md / AGENTS.md / setup.md document the limit. Latest (not prerelease) policy unchanged.

## After merge
Delete and re-push v0.1.1-beta on the new main tip so the release workflow can publish NSIS as Latest, then rewrite notes.

## Test plan
- [ ] CI green
- [ ] Greptile 5/5
- [ ] After merge: retag v0.1.1-beta, confirm NSIS on Latest Release